### PR TITLE
feat: add BYPASS_EMAIL env flag to skip SMTP in registration (#42)

### DIFF
--- a/language-exchange-backend/controllers/authController.js
+++ b/language-exchange-backend/controllers/authController.js
@@ -206,7 +206,7 @@ const User = require("../models/userModel");
 const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 const asyncHandler = require("express-async-handler");
-// const { sendVerificationEmail } = require("../services/emailService"); // <-- Comment out or remove this line
+const { sendVerificationEmail } = require("../services/emailService");
 
 // Generate JWT token
 const generateToken = (id) => {
@@ -266,12 +266,9 @@ const loginUser = asyncHandler(async (req, res) => {
   const { email, password } = req.body;
   const user = await User.findOne({ email });
 
-  // --- REMOVED THE isVerified CHECK HERE ---
-  // We no longer need to check isVerified because it's always true on creation
-  if (!user) { 
-    return res.status(401).json({ message: "Invalid email" }); // Changed message slightly
+  if (!user || (!BYPASS_EMAIL && !user.isVerified)) {
+    return res.status(401).json({ message: "Invalid email or not verified" });
   }
-  // --- END OF REMOVAL ---
 
   if (user.googleId) {
     return res.status(400).json({ message: "Use Auth0 login instead" });

--- a/language-exchange-backend/controllers/authController.js
+++ b/language-exchange-backend/controllers/authController.js
@@ -10,6 +10,7 @@ const { sendVerificationEmail } = require("../services/emailService");
 const generateToken = (id) => {
   return jwt.sign({ id }, process.env.JWT_SECRET, { expiresIn: "7d" });
 };
+const BYPASS_EMAIL = process.env.BYPASS_EMAIL === "true";
 
 const registerUser = asyncHandler(async (req, res) => {
   const { name, email, password } = req.body;
@@ -23,11 +24,15 @@ const registerUser = asyncHandler(async (req, res) => {
   }
 
   const hashedPassword = await bcrypt.hash(password, 10);
-  const user = await User.create({ name, email, password: hashedPassword });
+  const user = await User.create({ name, email, password: hashedPassword, isVerified: BYPASS_EMAIL });
 
   if (user) {
-    sendVerificationEmail(user);
-    res.status(201).json({ message: "Verification email sent" });
+    if (BYPASS_EMAIL) {
+      res.status(201).json({ message: "Registration successful! You can now log in." });
+    } else {
+      sendVerificationEmail(user);
+      res.status(201).json({ message: "Verification email sent" });
+    }
   } else {
     res.status(400).json({ message: "Invalid user data" });
   }
@@ -149,6 +154,10 @@ const forgotPassword = asyncHandler(async (req, res) => {
   if (!user) {
     res.status(404).json({ message: "User not found" });
     return;
+  }
+
+  if (BYPASS_EMAIL) {
+    return res.status(503).json({ message: "Password reset via email is disabled in this environment." });
   }
 
   sendVerificationEmail(user, "reset");

--- a/language-exchange-backend/services/emailService.js
+++ b/language-exchange-backend/services/emailService.js
@@ -1,5 +1,3 @@
-
-
 const nodemailer = require("nodemailer");
 const jwt = require("jsonwebtoken");
 require("dotenv").config();
@@ -16,8 +14,8 @@ const sendVerificationEmail = (user, type = "verify") => {
   const token = jwt.sign({ id: user._id }, process.env.JWT_SECRET, { expiresIn: "1h" });
 
   const url = type === "reset"
-    ? `${process.env.FRONTEND_URL}/${type}/${token}`  // Frontend for reset
-    : `${process.env.BACKEND_URL}/api/auth/${type}/${token}`;  // Backend for verify
+    ? `${process.env.FRONTEND_URL}/${type}/${token}`
+    : `${process.env.BACKEND_URL}/api/auth/${type}/${token}`;
 
   const mailOptions = {
     from: `"Language Exchange" <${process.env.EMAIL}>`,
@@ -35,14 +33,13 @@ const sendVerificationEmail = (user, type = "verify") => {
   });
 };
 
-
 const sendEmailService = async ({ to, subject, text, from }) => {
   const mailOptions = {
     from: from ? `"${from.name}" <${from.email}>` : `"Language Exchange" <${process.env.EMAIL}>`,
     to,
     subject,
     text,
-    replyTo: from ? from.email : process.env.EMAIL, // Add reply-to for sender's email
+    replyTo: from ? from.email : process.env.EMAIL,
   };
 
   try {
@@ -56,4 +53,3 @@ const sendEmailService = async ({ to, subject, text, from }) => {
 };
 
 module.exports = { sendVerificationEmail, sendEmailService, transporter };
-

--- a/language-exchange-frontend/src/components/LoginModal.jsx
+++ b/language-exchange-frontend/src/components/LoginModal.jsx
@@ -627,6 +627,8 @@ import { userApi } from '../redux/services/userApi'; // <-- Import userApi
 import { setCredentials } from '../redux/slices/authSlice';
 import { toast } from 'react-toastify';
 
+const BYPASS_EMAIL = import.meta.env.VITE_BYPASS_EMAIL === "true";
+
 const LoginModal = () => {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -749,16 +751,18 @@ const LoginModal = () => {
                   required
                 />
               </div>
-              <div className="mb-3 text-end">
-                <button
-                  type="button"
-                  className="btn btn-link p-0 text-decoration-none"
-                  onClick={handleForgotPassword}
-                  disabled={forgotLoading}
-                >
-                  Forgot Password?
-                </button>
-              </div>
+              {!BYPASS_EMAIL && (
+                <div className="mb-3 text-end">
+                  <button
+                    type="button"
+                    className="btn btn-link p-0 text-decoration-none"
+                    onClick={handleForgotPassword}
+                    disabled={forgotLoading}
+                  >
+                    Forgot Password?
+                  </button>
+                </div>
+              )}
               <button
                 type="submit"
                 className="btn btn-primary w-100 mb-3"

--- a/language-exchange-frontend/src/components/RegisterModal.jsx
+++ b/language-exchange-frontend/src/components/RegisterModal.jsx
@@ -14,8 +14,8 @@ const RegisterModal = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
-      await register({ name, email, password }).unwrap();
-      alert('Registration successful! Please verify your email.');
+      const data = await register({ name, email, password }).unwrap();
+      alert(data.message || 'Registration successful!');
       navigate('/login'); // Redirect to login route
     } catch (err) {
       alert(err.data?.message || 'Registration failed');


### PR DESCRIPTION
## Summary
- Adds `BYPASS_EMAIL` env variable on backend — when `true`, users are registered with `isVerified: true` and no verification email is sent
- Adds `VITE_BYPASS_EMAIL` env variable on frontend — when `true`, hides the Forgot Password button (since email-based reset is unavailable)
- RegisterModal now uses the backend response message instead of a hardcoded string, so the correct message shows in both modes

## Why
Render's free tier blocks outbound SMTP, causing registration to silently fail on the deployed site. This flag lets us disable email flows in deployment while keeping the full email verification working in local dev.

## How to use
**Local dev** (full email flow):
- Don't set `BYPASS_EMAIL` or set it to `false`

**Render deployment** (no email):
- Backend env: `BYPASS_EMAIL=true`
- Frontend env: `VITE_BYPASS_EMAIL=true`

## Closes
Closes #42
