### PR TITLE
feat: dark glassmorphism UI redesign + language normalization (#46)

### DIFF
--- a/language-exchange-frontend/src/components/Home.jsx
+++ b/language-exchange-frontend/src/components/Home.jsx
@@ -26,11 +26,21 @@ const Home = () => {
   } = useCallLogic();
 
   if (isAuthenticated && callLoading && !callStatus) {
-    return <div className="text-center mt-5" style={{ color: '#393f4d' }}>Loading call status...</div>;
+    return <div className="text-center mt-5" style={{ color: '#e2e8f0' }}>Loading call status...</div>;
   }
 
+  const partnerName = callStatus
+    ? callStatus.callerId === user?._id ? callStatus.receiver : callStatus.caller
+    : '';
+
+  const durSec = callStatus?.status === 'active' ? getCallDuration() : 0;
+  const durMin = Math.floor(durSec / 60);
+  const durSecRem = (durSec % 60).toString().padStart(2, '0');
+  const progress = callStatus?.status === 'active' ? getCallDurationProgress() : 0;
+
   return (
-    <div style={{ backgroundColor: '#FFFFFF', minHeight: '100vh', padding: 0, margin: 0 }}>
+    <div>
+      {/* Hero */}
       <div className="hero-section">
         <div className="globe"></div>
         <div className="particles">
@@ -43,196 +53,226 @@ const Home = () => {
         <p className="hero-subtitle">Connect with language partners worldwide in real-time</p>
       </div>
 
-      <div
-        className="call-initiator"
-        style={{
-          maxWidth: '500px',
-          margin: '0 auto',
-          padding: '20px',
-          boxSizing: 'border-box',
-          backgroundColor: '#e9ecef',
-          borderRadius: '8px',
-        }}
-      >
+      {/* Call initiator card */}
+      <div className="call-initiator">
         {isAuthenticated ? (
           callStatus ? (
-            <div
-              className="call-card"
-              style={{
-                width: '100%',
-                margin: 0,
-                padding: 0,
-                background: 'transparent',
-                boxSizing: 'border-box',
-              }}
-            >
-              <h5 className="card-title">Call Status</h5>
-              {callStatus.status === 'pending' && callStatus.callerId === user?._id ? (
+            <div className="call-card">
+              <p className="call-card-title">Call Status</p>
+
+              {/* Pending — you are the caller */}
+              {callStatus.status === 'pending' && callStatus.callerId === user?._id && (
                 <>
-                  <p>Waiting for someone to accept your call for <strong>{callStatus.language}</strong>...</p>
-                  {callStatus.receivers && callStatus.receivers.length > 0 ? (
-                    <p style={{ color: '#feda6a' }}>
-                      Potential Receivers: {callStatus.receivers.map((r) => r.name || r.id || 'Unknown').join(', ')}
+                  <div className="incoming-ring" style={{ background: 'rgba(254,218,106,0.1)' }}>
+                    <i className="bi bi-telephone-outbound-fill" style={{ fontSize: '1.8rem', color: '#feda6a' }}></i>
+                  </div>
+                  <p className="call-partner-name">Calling…</p>
+                  <p style={{ color: '#94a3b8', textAlign: 'center', fontSize: '0.88rem', marginBottom: '1.4rem' }}>
+                    Waiting for someone to accept your call for{' '}
+                    <strong style={{ color: '#feda6a' }}>{callStatus.language}</strong>
+                  </p>
+                  {callStatus.receivers && callStatus.receivers.length > 0 && (
+                    <p style={{ color: '#64748b', textAlign: 'center', fontSize: '0.8rem', marginBottom: '1rem' }}>
+                      Reaching: {callStatus.receivers.map((r) => r.name || r.id || 'Unknown').join(', ')}
                     </p>
-                  ) : (
-                    <p>No potential receivers left.</p>
                   )}
-                  <button className="btn btn-danger-custom w-100" onClick={handleCancelCall}>
-                    Cancel Call
+                  <button className="call-btn call-btn-cancel" onClick={handleCancelCall}>
+                    <i className="bi bi-telephone-x-fill"></i> Cancel Call
                   </button>
                 </>
-              ) : callStatus.status === 'pending' && callStatus.caller && callStatus.callerId !== user?._id ? (
+              )}
+
+              {/* Pending — incoming call */}
+              {callStatus.status === 'pending' && callStatus.caller && callStatus.callerId !== user?._id && (
                 <>
-                  <p>Incoming call from <strong>{callStatus.caller}</strong> for <strong>{callStatus.language}</strong></p>
-                  <div className="d-flex gap-2">
-                    <button className="btn btn-success-custom w-50" onClick={handleAcceptCall}>
-                      Accept Call
+                  <div className="incoming-ring">
+                    <i className="bi bi-telephone-inbound-fill"></i>
+                  </div>
+                  <p className="call-partner-name">{callStatus.caller}</p>
+                  <span className="call-language-tag">
+                    <i className="bi bi-translate"></i>
+                    {callStatus.language}
+                  </span>
+                  <div style={{ display: 'flex', flexDirection: 'column', gap: '0.7rem' }}>
+                    <button className="call-btn call-btn-accept" onClick={handleAcceptCall}>
+                      <i className="bi bi-telephone-fill"></i> Accept
                     </button>
-                    <button className="btn btn-danger-custom w-50" onClick={handleRejectCall}>
-                      Reject Call
+                    <button className="call-btn call-btn-reject" onClick={handleRejectCall}>
+                      <i className="bi bi-telephone-x-fill"></i> Decline
                     </button>
                   </div>
                 </>
-              ) : callStatus.status === 'active' ? (
+              )}
+
+              {/* Active call */}
+              {callStatus.status === 'active' && (
                 <>
-                  <p>
-                    Active call with{' '}
-                    <strong>{callStatus.callerId === user?._id ? callStatus.receiver : callStatus.caller}</strong>
-                  </p>
-                  <p>
-                    Call Duration: {Math.floor(getCallDuration() / 60)}:
-                    {(getCallDuration() % 60).toString().padStart(2, '0')}
-                  </p>
-                  <div
-                    style={{
-                      height: '5px',
-                      backgroundColor: '#e0e0e0',
-                      borderRadius: '2.5px',
-                      overflow: 'hidden',
-                      margin: '10px 0',
-                    }}
-                  >
+                  <p className="call-partner-name">{partnerName}</p>
+                  <span className="call-language-tag">
+                    <i className="bi bi-circle-fill" style={{ fontSize: '0.5rem', color: '#4ade80' }}></i>
+                    Live
+                  </span>
+
+                  <div className="call-duration-row">
+                    <i className="bi bi-clock" style={{ fontSize: '1.1rem', color: '#94a3b8' }}></i>
+                    {durMin}:{durSecRem}
+                  </div>
+
+                  <div className="call-progress-track">
                     <div
+                      className="call-progress-fill"
                       style={{
-                        width: `${getCallDurationProgress()}%`,
-                        height: '100%',
-                        backgroundColor: getCallDurationProgress() >= 100 ? '#ff4d4f' : '#feda6a',
-                        transition: 'width 1s linear, background-color 0.3s ease',
+                        width: `${progress}%`,
+                        background: progress >= 100 ? '#e53e3e' : '#feda6a',
                       }}
                     ></div>
                   </div>
-                  {callStatus.extended && <p style={{ color: '#feda6a' }}>Call Extended!</p>}
+
+                  {callStatus.extended && (
+                    <div className="call-extended-badge">
+                      <i className="bi bi-plus-circle-fill"></i> Extended
+                    </div>
+                  )}
+
                   <audio autoPlay playsInline muted={true} ref={(el) => el && (el.srcObject = localStream)} />
                   <audio autoPlay playsInline muted={false} ref={(el) => el && (el.srcObject = remoteStream)} />
-                  <div className="d-flex flex-column gap-2">
-                    <button className="btn btn-danger-custom w-100" onClick={handleEndCall}>
-                      End Call
-                    </button>
-                    <button className="btn btn-secondary-custom w-100" onClick={toggleMute}>
+
+                  <div className="call-controls">
+                    <button
+                      className={`ctrl-btn ${callStatus.isMuted ? 'muted' : 'mute-btn'}`}
+                      onClick={toggleMute}
+                    >
+                      <i className={`bi ${callStatus.isMuted ? 'bi-mic-mute-fill' : 'bi-mic-fill'}`}></i>
                       {callStatus.isMuted ? 'Unmute' : 'Mute'}
                     </button>
+                    <button className="ctrl-btn end-btn" onClick={handleEndCall}>
+                      <i className="bi bi-telephone-x-fill"></i>
+                      End
+                    </button>
                     <button
-                      className="btn btn-warning-custom w-100"
+                      className="ctrl-btn extend-btn"
                       onClick={handleExtendCall}
                       disabled={!user?.powerTokens || user.powerTokens < 1 || extendRequest}
                     >
-                      {user?.powerTokens < 1
-                        ? 'No Power Tokens'
-                        : extendRequest
-                        ? 'Awaiting Approval'
-                        : 'Extend Call'}
+                      <i className="bi bi-clock-history"></i>
+                      {extendRequest ? 'Pending…' : 'Extend'}
                     </button>
                   </div>
+
                   {extendRequest && extendRequest.callId === callStatus.callId && (
-                    <div className="mt-3">
-                      <p>{extendRequest.requesterName} wants to extend the call. Approve?</p>
-                      <div className="d-flex gap-2">
-                        <button
-                          className="btn btn-success-custom w-50"
-                          onClick={() => handleApproveExtend(true)}
-                        >
-                          Yes
+                    <div className="extend-request-box">
+                      <p style={{ color: '#cbd5e1', fontSize: '0.88rem', marginBottom: '0.8rem', textAlign: 'center' }}>
+                        <strong style={{ color: '#feda6a' }}>{extendRequest.requesterName}</strong> wants to extend the call
+                      </p>
+                      <div style={{ display: 'flex', gap: '0.7rem' }}>
+                        <button className="call-btn call-btn-accept" style={{ flex: 1 }} onClick={() => handleApproveExtend(true)}>
+                          <i className="bi bi-check-lg"></i> Yes
                         </button>
-                        <button
-                          className="btn btn-danger-custom w-50"
-                          onClick={() => handleApproveExtend(false)}
-                        >
-                          No
+                        <button className="call-btn call-btn-reject" style={{ flex: 1 }} onClick={() => handleApproveExtend(false)}>
+                          <i className="bi bi-x-lg"></i> No
                         </button>
                       </div>
                     </div>
                   )}
                 </>
-              ) : (
-                <p>Call <strong>{callStatus.status}</strong>!</p>
+              )}
+
+              {/* Fallback status */}
+              {callStatus.status !== 'pending' && callStatus.status !== 'active' && (
+                <p style={{ color: '#94a3b8', textAlign: 'center' }}>
+                  Call <strong style={{ color: '#feda6a' }}>{callStatus.status}</strong>
+                </p>
               )}
             </div>
           ) : (
             <>
-              <h5>Start a Language Call</h5>
-              <div className="d-flex gap-3 align-items-center">
+              <h5 style={{ color: '#feda6a', fontWeight: 700, marginBottom: '1rem' }}>Start a Language Call</h5>
+              <div className="lang-input-row">
                 <input
                   type="text"
-                  className="form-control"
+                  className="lang-input"
                   placeholder="Enter language (e.g., Spanish)"
                   value={language}
                   onChange={(e) => setLanguage(e.target.value)}
                 />
                 <button
-                  className="btn btn-primary-custom"
+                  className="btn-primary-custom"
                   onClick={handleInitiateCall}
                   disabled={!language || !user?.powerTokens || user.powerTokens < 1}
                 >
-                  {user?.powerTokens < 1 ? 'No Power Tokens' : 'Initiate Call'}
+                  {user?.powerTokens < 1 ? 'No Tokens' : 'Call'}
                 </button>
               </div>
             </>
           )
         ) : (
-          <div
-            className="alert alert-info-custom"
-            style={{
-              width: '100%',
-              margin: 0,
-              padding: 0,
-              background: 'transparent',
-              boxSizing: 'border-box',
-            }}
-          >
-            Please <Link to="/login">login</Link> to start exchanging languages!
+          <div className="auth-alert">
+            Please <Link to="/login">sign in</Link> to start exchanging languages!
           </div>
         )}
       </div>
 
-      <div className="feature-section container">
-        <div className="row g-4">
-          <div className="col-md-4">
-            <div className="feature-card">
-              <i className="bi bi-mic-fill feature-icon"></i>
-              <h5>Live Calls</h5>
-              <p style={{ color: '#393f4d' }}>Practice speaking with real people instantly.</p>
+      {/* Stats strip */}
+      <div className="stats-strip">
+        <div className="container">
+          <div className="row">
+            <div className="col-4 stat-item">
+              <div className="stat-number">50+</div>
+              <div className="stat-label">Languages</div>
             </div>
-          </div>
-          <div className="col-md-4">
-            <div className="feature-card">
-              <i className="bi bi-globe feature-icon"></i>
-              <h5>Global Reach</h5>
-              <p style={{ color: '#393f4d' }}>Connect with learners across the globe.</p>
+            <div className="col-4 stat-item">
+              <div className="stat-number">1K+</div>
+              <div className="stat-label">Users</div>
             </div>
-          </div>
-          <div className="col-md-4">
-            <div className="feature-card">
-              <i className="bi bi-star-fill feature-icon"></i>
-              <h5>Rewards</h5>
-              <p style={{ color: '#393f4d' }}>Earn tokens while teaching others.</p>
+            <div className="col-4 stat-item">
+              <div className="stat-number">24/7</div>
+              <div className="stat-label">Live Calls</div>
             </div>
           </div>
         </div>
       </div>
 
-      <div className="footer">
-        <p>© 2025 Language Exchange. Connecting the World, One Word at a Time.</p>
-      </div>
+      {/* Feature cards */}
+      <section className="feature-section">
+        <div className="container">
+          <h2 className="feature-section-title">Why Language Exchange?</h2>
+          <p className="feature-section-sub">Real people, real conversations, real progress</p>
+          <div className="row g-4">
+            <div className="col-md-4">
+              <div className="feature-card">
+                <div className="feature-icon-wrap">
+                  <i className="bi bi-mic-fill feature-icon"></i>
+                </div>
+                <h5>Live Calls</h5>
+                <p>Practice speaking with real people instantly — no scheduling needed.</p>
+              </div>
+            </div>
+            <div className="col-md-4">
+              <div className="feature-card">
+                <div className="feature-icon-wrap">
+                  <i className="bi bi-globe feature-icon"></i>
+                </div>
+                <h5>Global Reach</h5>
+                <p>Connect with learners across the globe, any time of day.</p>
+              </div>
+            </div>
+            <div className="col-md-4">
+              <div className="feature-card">
+                <div className="feature-icon-wrap">
+                  <i className="bi bi-star-fill feature-icon"></i>
+                </div>
+                <h5>Earn Rewards</h5>
+                <p>Collect tokens while teaching others your native language.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="footer">
+        <p>© 2025 Language Exchange. Connecting the World, One Word at a Time. Made with <span>♥</span></p>
+      </footer>
     </div>
   );
 };

--- a/language-exchange-frontend/src/components/Premium.jsx
+++ b/language-exchange-frontend/src/components/Premium.jsx
@@ -7,6 +7,7 @@ import { setCallStatus } from '../redux/slices/authSlice';
 import { toast } from 'react-toastify';
 import EmailModal from './EmailModal';
 import useCallLogic from '../hooks/useCallLogic';
+import '../styles/Home.css';
 
 const Premium = () => {
   const { user, isAuthenticated, callStatus } = useSelector((state) => state.auth);
@@ -86,253 +87,266 @@ const Premium = () => {
 
   if (!isAuthenticated) {
     return (
-      <div className="text-center mt-5">
-        <p className="text-secondary">Please log in to access this page.</p>
+      <div style={{ color: '#94a3b8', textAlign: 'center', marginTop: '80px' }}>
+        Please log in to access this page.
       </div>
     );
   }
 
   if (!user?.premium) {
-      // Logic for non-premium users to upgrade is now handled by the Store page
-      // and a redirect or link from the Navbar. This page is for premium users only.
     return (
-        <div className="bg-white min-vh-100 pt-5 text-center">
-        <h2 className="text-dark fw-bold">Upgrade to Premium</h2>
-        <p className="text-secondary fs-5 mb-3"> 
-          This is a premium feature. Please visit the store to upgrade.
-        </p>
-        <Link 
-            to="/store"
-            className="btn btn-warning text-dark fw-bold px-4 py-2 rounded-pill shadow-sm"
-        >
-            Go to Store
-        </Link>
+      <div style={{ background: '#0f1117', minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', flexDirection: 'column', gap: '1.2rem', padding: '2rem' }}>
+        <div style={{ width: '72px', height: '72px', borderRadius: '50%', background: 'rgba(254,218,106,0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <i className="bi bi-star-fill" style={{ fontSize: '2rem', color: '#feda6a' }}></i>
         </div>
+        <h2 style={{ color: '#f1f5f9', fontWeight: '800', margin: 0 }}>Upgrade to Premium</h2>
+        <p style={{ color: '#64748b', textAlign: 'center', maxWidth: '360px', margin: 0 }}>
+          Unlock selective calling, view all users, and send emails directly.
+        </p>
+        <Link to="/store" style={{ background: '#feda6a', color: '#1d1e22', fontWeight: '700', padding: '10px 28px', borderRadius: '50px', textDecoration: 'none' }}>
+          Go to Store
+        </Link>
+      </div>
     );
   }
 
+  const partnerName = callStatus
+    ? callStatus.callerId === user?._id ? callStatus.receiver : callStatus.caller
+    : '';
+  const durSec = callStatus?.status === 'active' ? getCallDuration() : 0;
+  const durMin = Math.floor(durSec / 60);
+  const durSecRem = (durSec % 60).toString().padStart(2, '0');
+  const progress = callStatus?.status === 'active' ? getCallDurationProgress() : 0;
+
   return (
-    <div className="container py-4">
-      <h2 className="text-center text-dark fw-bold mb-3">Premium Dashboard</h2>
+    <div style={{ background: '#0f1117', minHeight: '100vh', padding: '2rem 1rem', fontFamily: "'Inter', sans-serif" }}>
+      <div className="container">
 
-      <div className="text-center mb-3">
-        <Link
-          to="/store"
-          className="btn btn-dark text-warning fw-bold px-3 py-2 rounded-pill"
-        >
-          Buy More Tokens or Coins
-        </Link>
-      </div>
+        {/* Header */}
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', flexWrap: 'wrap', gap: '1rem', marginBottom: '2rem' }}>
+          <div>
+            <h2 style={{ color: '#f1f5f9', fontWeight: '800', margin: 0 }}>Premium Dashboard</h2>
+            <p style={{ color: '#64748b', margin: 0, fontSize: '0.9rem' }}>Welcome back, {user?.name}</p>
+          </div>
+          <div style={{ display: 'flex', gap: '0.7rem', alignItems: 'center', flexWrap: 'wrap' }}>
+            <span style={{ background: 'rgba(254,218,106,0.12)', color: '#feda6a', borderRadius: '20px', padding: '5px 14px', fontSize: '0.82rem', fontWeight: '600' }}>
+              <i className="bi bi-lightning-fill" style={{ marginRight: '5px' }}></i>{user?.powerTokens ?? 0} Power
+            </span>
+            <span style={{ background: 'rgba(99,179,237,0.12)', color: '#63b3ed', borderRadius: '20px', padding: '5px 14px', fontSize: '0.82rem', fontWeight: '600' }}>
+              <i className="bi bi-coin" style={{ marginRight: '5px' }}></i>{user?.coinTokens ?? 0} Coins
+            </span>
+            <Link to="/store" style={{ background: 'rgba(254,218,106,0.12)', color: '#feda6a', borderRadius: '20px', padding: '5px 14px', fontSize: '0.82rem', fontWeight: '600', textDecoration: 'none', border: '1px solid rgba(254,218,106,0.2)' }}>
+              <i className="bi bi-bag-fill" style={{ marginRight: '5px' }}></i>Store
+            </Link>
+          </div>
+        </div>
 
-      {callStatus ? (
-        <div className="card mx-auto mb-4 shadow-sm" style={{ maxWidth: '500px' }}>
-          <div className="card-body">
-            <h5 className="card-title text-dark fw-bold mb-3">Call Status</h5>
-            {callStatus.status === 'pending' && callStatus.callerId === user?._id ? (
+        {/* Call section */}
+        <div style={{ maxWidth: '540px', margin: '0 auto 2.5rem' }}>
+          <div style={{ background: 'rgba(22,25,35,0.92)', border: '1px solid rgba(254,218,106,0.18)', borderRadius: '20px', padding: '2rem', backdropFilter: 'blur(12px)' }}>
+
+            {callStatus ? (
               <>
-                <p className="text-secondary">Waiting for someone to accept your call...</p>
-                {callStatus.receivers && callStatus.receivers.length > 0 ? (
-                  <p className="text-warning">
-                    Potential Receivers: {callStatus.receivers.map((r) => r.name || r.id || 'Unknown').join(', ')}
-                  </p>
-                ) : (
-                  <p>No potential receivers left.</p>
+                <p style={{ fontSize: '0.72rem', fontWeight: '700', letterSpacing: '0.12em', textTransform: 'uppercase', color: 'rgba(254,218,106,0.7)', marginBottom: '1.2rem' }}>Call Status</p>
+
+                {/* Pending — caller */}
+                {callStatus.status === 'pending' && callStatus.callerId === user?._id && (
+                  <>
+                    <div style={{ width: '64px', height: '64px', borderRadius: '50%', background: 'rgba(254,218,106,0.1)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 1rem' }}>
+                      <i className="bi bi-telephone-outbound-fill" style={{ fontSize: '1.6rem', color: '#feda6a' }}></i>
+                    </div>
+                    <p style={{ color: '#f1f5f9', fontWeight: '700', textAlign: 'center', fontSize: '1.1rem', marginBottom: '0.3rem' }}>Calling…</p>
+                    <p style={{ color: '#64748b', textAlign: 'center', fontSize: '0.85rem', marginBottom: '1.4rem' }}>
+                      Waiting for <strong style={{ color: '#feda6a' }}>{callStatus.receivers?.[0]?.name || 'user'}</strong>
+                    </p>
+                    <button
+                      onClick={handleCancelCall}
+                      style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '8px', width: '100%', padding: '11px', border: '1px solid rgba(229,62,62,0.3)', borderRadius: '12px', background: 'rgba(229,62,62,0.12)', color: '#fc8181', fontWeight: '600', cursor: 'pointer', fontSize: '0.9rem' }}
+                    >
+                      <i className="bi bi-telephone-x-fill"></i> Cancel Call
+                    </button>
+                  </>
                 )}
-                <button
-                  onClick={handleCancelCall}
-                  className="btn btn-dark text-warning w-100 rounded-pill"
-                >
-                  Cancel Call
-                </button>
-              </>
-            ) : callStatus.status === 'pending' && callStatus.callerId !== user?._id ? (
-              <>
-                <p className="text-secondary">
-                  Incoming call from <strong>{callStatus.caller}</strong> for <strong>{callStatus.language}</strong>
-                </p>
-                <div className="d-flex gap-3">
-                  <button
-                    onClick={handleAcceptCall}
-                    className="btn btn-warning text-dark w-50 rounded-pill"
-                  >
-                    Accept Call
-                  </button>
-                  <button
-                    onClick={handleRejectCall}
-                    className="btn btn-dark text-warning w-50 rounded-pill"
-                  >
-                    Reject Call
-                  </button>
-                </div>
-              </>
-            ) : callStatus.status === 'active' ? (
-              <>
-                <p className="text-secondary">
-                  Active call with <strong>{callStatus.callerId === user?._id ? callStatus.receiver : callStatus.caller}</strong>
-                </p>
-                <p className="text-secondary">
-                  Call Duration: {Math.floor(getCallDuration() / 60)}:{(getCallDuration() % 60).toString().padStart(2, '0')}
-                </p>
-                <div className="progress mb-2" style={{ height: '5px' }}>
-                  <div
-                    className={`progress-bar ${getCallDurationProgress() >= 100 ? 'bg-danger' : 'bg-warning'}`}
-                    style={{ width: `${getCallDurationProgress()}%` }}
-                  ></div>
-                </div>
-                {callStatus.extended && <p className="text-warning">Call Extended!</p>}
-                <audio autoPlay playsInline muted={true} ref={(el) => el && (el.srcObject = localStream)} />
-                <audio autoPlay playsInline muted={false} ref={(el) => el && (el.srcObject = remoteStream)} />
-                <div className="d-flex flex-column gap-2">
-                  <button
-                    onClick={handleEndCall}
-                    className="btn btn-dark text-warning rounded-pill"
-                  >
-                    End Call
-                  </button>
-                  <button
-                    onClick={toggleMute}
-                    className="btn btn-dark text-warning rounded-pill"
-                  >
-                    {callStatus.isMuted ? 'Unmute' : 'Mute'}
-                  </button>
-                  <button
-                    onClick={handleExtendCall}
-                    disabled={!user?.powerTokens || user.powerTokens < 1 || extendRequest}
-                    className="btn btn-warning text-dark rounded-pill"
-                  >
-                    {extendRequest ? 'Awaiting Approval' : 'Extend Call'}
-                  </button>
-                </div>
-                {extendRequest && (
-                  <div className="mt-3">
-                    <p className="text-secondary">{extendRequest.requesterName} wants to extend the call. Approve?</p>
-                    <div className="d-flex gap-3">
-                      <button
-                        onClick={() => handleApproveExtend(true)}
-                        className="btn btn-warning text-dark w-50 rounded-pill"
-                      >
-                        Yes
+
+                {/* Pending — incoming */}
+                {callStatus.status === 'pending' && callStatus.caller && callStatus.callerId !== user?._id && (
+                  <>
+                    <div className="incoming-ring" style={{ margin: '0 auto 1rem' }}>
+                      <i className="bi bi-telephone-inbound-fill" style={{ fontSize: '1.8rem', color: '#feda6a' }}></i>
+                    </div>
+                    <p style={{ color: '#f1f5f9', fontWeight: '700', textAlign: 'center', fontSize: '1.3rem', marginBottom: '0.3rem' }}>{callStatus.caller}</p>
+                    <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '1.4rem' }}>
+                      <span style={{ background: 'rgba(254,218,106,0.12)', color: '#feda6a', fontSize: '0.82rem', fontWeight: '600', padding: '3px 12px', borderRadius: '20px', display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+                        <i className="bi bi-translate"></i>{callStatus.language}
+                      </span>
+                    </div>
+                    <div style={{ display: 'flex', gap: '0.7rem' }}>
+                      <button onClick={handleAcceptCall} style={{ flex: 1, padding: '11px', borderRadius: '12px', border: 'none', background: '#38a169', color: '#fff', fontWeight: '600', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '7px' }}>
+                        <i className="bi bi-telephone-fill"></i> Accept
                       </button>
-                      <button
-                        onClick={() => handleApproveExtend(false)}
-                        className="btn btn-dark text-warning w-50 rounded-pill"
-                      >
-                        No
+                      <button onClick={handleRejectCall} style={{ flex: 1, padding: '11px', borderRadius: '12px', border: 'none', background: '#e53e3e', color: '#fff', fontWeight: '600', cursor: 'pointer', display: 'flex', alignItems: 'center', justifyContent: 'center', gap: '7px' }}>
+                        <i className="bi bi-telephone-x-fill"></i> Decline
                       </button>
                     </div>
-                  </div>
+                  </>
+                )}
+
+                {/* Active */}
+                {callStatus.status === 'active' && (
+                  <>
+                    <p style={{ color: '#f1f5f9', fontWeight: '700', textAlign: 'center', fontSize: '1.3rem', marginBottom: '0.3rem' }}>{partnerName}</p>
+                    <div style={{ display: 'flex', justifyContent: 'center', marginBottom: '1rem' }}>
+                      <span style={{ background: 'rgba(74,222,128,0.12)', color: '#4ade80', fontSize: '0.8rem', fontWeight: '600', padding: '3px 12px', borderRadius: '20px', display: 'inline-flex', alignItems: 'center', gap: '6px' }}>
+                        <i className="bi bi-circle-fill" style={{ fontSize: '0.45rem' }}></i>Live
+                      </span>
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '8px', fontSize: '1.5rem', fontWeight: '700', color: '#f1f5f9', justifyContent: 'center', marginBottom: '0.5rem', fontVariantNumeric: 'tabular-nums' }}>
+                      <i className="bi bi-clock" style={{ fontSize: '1.1rem', color: '#94a3b8' }}></i>
+                      {durMin}:{durSecRem}
+                    </div>
+                    <div style={{ height: '4px', background: 'rgba(255,255,255,0.1)', borderRadius: '2px', overflow: 'hidden', marginBottom: '1.2rem' }}>
+                      <div style={{ height: '100%', borderRadius: '2px', width: `${progress}%`, background: progress >= 100 ? '#e53e3e' : '#feda6a', transition: 'width 1s linear, background-color 0.3s ease' }}></div>
+                    </div>
+                    {callStatus.extended && (
+                      <div style={{ display: 'inline-flex', alignItems: 'center', gap: '6px', background: 'rgba(254,218,106,0.12)', color: '#feda6a', fontSize: '0.8rem', fontWeight: '600', padding: '4px 12px', borderRadius: '20px', marginBottom: '0.8rem' }}>
+                        <i className="bi bi-plus-circle-fill"></i> Extended
+                      </div>
+                    )}
+                    <audio autoPlay playsInline muted={true} ref={(el) => el && (el.srcObject = localStream)} />
+                    <audio autoPlay playsInline muted={false} ref={(el) => el && (el.srcObject = remoteStream)} />
+                    <div className="call-controls">
+                      <button className={`ctrl-btn ${callStatus.isMuted ? 'muted' : 'mute-btn'}`} onClick={toggleMute}>
+                        <i className={`bi ${callStatus.isMuted ? 'bi-mic-mute-fill' : 'bi-mic-fill'}`}></i>
+                        {callStatus.isMuted ? 'Unmute' : 'Mute'}
+                      </button>
+                      <button className="ctrl-btn end-btn" onClick={handleEndCall}>
+                        <i className="bi bi-telephone-x-fill"></i>End
+                      </button>
+                      <button
+                        className="ctrl-btn extend-btn"
+                        onClick={handleExtendCall}
+                        disabled={!user?.powerTokens || user.powerTokens < 1 || extendRequest}
+                      >
+                        <i className="bi bi-clock-history"></i>
+                        {extendRequest ? 'Pending…' : 'Extend'}
+                      </button>
+                    </div>
+                    {extendRequest && (
+                      <div style={{ background: 'rgba(254,218,106,0.08)', border: '1px solid rgba(254,218,106,0.2)', borderRadius: '12px', padding: '1rem', marginTop: '1rem' }}>
+                        <p style={{ color: '#cbd5e1', fontSize: '0.88rem', marginBottom: '0.8rem', textAlign: 'center' }}>
+                          <strong style={{ color: '#feda6a' }}>{extendRequest.requesterName}</strong> wants to extend
+                        </p>
+                        <div style={{ display: 'flex', gap: '0.7rem' }}>
+                          <button onClick={() => handleApproveExtend(true)} style={{ flex: 1, padding: '10px', borderRadius: '10px', border: 'none', background: '#38a169', color: '#fff', fontWeight: '600', cursor: 'pointer' }}>Yes</button>
+                          <button onClick={() => handleApproveExtend(false)} style={{ flex: 1, padding: '10px', borderRadius: '10px', border: 'none', background: '#e53e3e', color: '#fff', fontWeight: '600', cursor: 'pointer' }}>No</button>
+                        </div>
+                      </div>
+                    )}
+                  </>
+                )}
+
+                {callStatus.status !== 'pending' && callStatus.status !== 'active' && (
+                  <p style={{ color: '#94a3b8', textAlign: 'center' }}>
+                    Call <strong style={{ color: '#feda6a' }}>{callStatus.status}</strong>
+                  </p>
                 )}
               </>
             ) : (
-              <p className="text-secondary">Call <strong>{callStatus.status}</strong>!</p>
+              <>
+                <h5 style={{ color: '#feda6a', fontWeight: '700', marginBottom: '1rem' }}>Start a Random Language Call</h5>
+                <div className="lang-input-row">
+                  <input
+                    type="text"
+                    placeholder="Enter language to learn"
+                    value={language}
+                    onChange={(e) => setLanguage(e.target.value)}
+                    className="lang-input"
+                  />
+                  <button className="btn-primary-custom" onClick={handleInitiateCall}>
+                    Call
+                  </button>
+                </div>
+              </>
             )}
           </div>
         </div>
-      ) : (
-        <div className="card mx-auto mb-4 shadow-sm" style={{ maxWidth: '400px' }}>
-          <div className="card-body">
-            <h5 className="card-title text-dark fw-bold mb-3">Start a Random Language Call</h5>
-            <div className="d-flex flex-column flex-sm-row gap-3 align-items-sm-center">
-              <input
-                type="text"
-                placeholder="Enter language to learn"
-                value={language}
-                onChange={(e) => setLanguage(e.target.value)}
-                className="form-control rounded-pill"
-              />
-              <button
-                onClick={handleInitiateCall}
-                className="btn btn-dark text-warning rounded-pill px-4"
-              >
-                Initiate Call
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
 
-      <div className="card shadow-sm">
-        <div className="card-body">
-          <h5 className="card-title text-dark fw-bold mb-3">Available Users</h5>
-          <div className="d-flex flex-column flex-sm-row gap-3 align-items-sm-center mb-3">
+        {/* Users table */}
+        <div style={{ background: 'rgba(22,25,35,0.85)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: '20px', padding: '1.5rem', backdropFilter: 'blur(8px)' }}>
+          <h5 style={{ color: '#f1f5f9', fontWeight: '700', marginBottom: '1.2rem' }}>Available Users</h5>
+          <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap', alignItems: 'center', marginBottom: '1.2rem' }}>
             <input
               type="text"
-              placeholder="Search users by name, email, or languages"
+              placeholder="Search by name, email, or language…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="form-control rounded-pill"
+              style={{ flex: 1, minWidth: '200px', background: 'rgba(255,255,255,0.06)', border: '1px solid rgba(255,255,255,0.12)', color: '#f1f5f9', borderRadius: '10px', padding: '9px 14px', fontSize: '0.9rem', outline: 'none' }}
             />
-            <div className="form-check">
+            <label style={{ display: 'flex', alignItems: 'center', gap: '8px', color: '#94a3b8', fontSize: '0.88rem', cursor: 'pointer', userSelect: 'none' }}>
               <input
                 type="checkbox"
                 checked={showPremiumOnly}
                 onChange={(e) => setShowPremiumOnly(e.target.checked)}
-                className="form-check-input"
-                id="premiumOnly"
+                style={{ accentColor: '#feda6a', width: '16px', height: '16px' }}
               />
-              <label className="form-check-label text-secondary" htmlFor="premiumOnly">
-                Show Premium Users Only
-              </label>
-            </div>
+              Premium only
+            </label>
           </div>
+
           {isLoading ? (
-            <p className="text-center text-secondary">Loading users...</p>
+            <p style={{ color: '#64748b', textAlign: 'center' }}>Loading users…</p>
           ) : error ? (
-            <p className="text-center text-secondary">
-              Error: {error.data?.error || 'Failed to load users'}
-            </p>
+            <p style={{ color: '#fc8181', textAlign: 'center' }}>Error: {error.data?.error || 'Failed to load users'}</p>
           ) : (
-            <div className="table-responsive">
-              <table className="table table-hover">
-                <thead className="table-dark text-warning">
-                  <tr>
-                    <th scope="col">Name</th>
-                    <th scope="col">Status</th>
-                    <th scope="col" className="d-none d-md-table-cell">Known Languages</th>
-                    <th scope="col" className="d-none d-md-table-cell">Learning Languages</th>
-                    <th scope="col">Actions</th>
+            <div style={{ overflowX: 'auto' }}>
+              <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.88rem' }}>
+                <thead>
+                  <tr style={{ borderBottom: '1px solid rgba(255,255,255,0.08)' }}>
+                    {['Name', 'Status', 'Knows', 'Learning', 'Actions'].map(h => (
+                      <th key={h} style={{ color: 'rgba(254,218,106,0.7)', fontWeight: '700', fontSize: '0.72rem', letterSpacing: '0.1em', textTransform: 'uppercase', padding: '10px 12px', textAlign: 'left' }}>{h}</th>
+                    ))}
                   </tr>
                 </thead>
                 <tbody>
                   {filteredUsers.map(u => (
-                    <tr key={u._id}>
-                      <td>
-                        <Link to={`/profile/${u._id}`} className="text-decoration-none text-secondary">
+                    <tr key={u._id} style={{ borderBottom: '1px solid rgba(255,255,255,0.04)' }}>
+                      <td style={{ padding: '10px 12px' }}>
+                        <Link to={`/profile/${u._id}`} style={{ color: '#f1f5f9', textDecoration: 'none', fontWeight: '600' }}>
                           {u.name}
-                          {u.premium && (
-                            <i className="bi bi-star-fill ms-2 text-warning" title="Premium User" />
-                          )}
+                          {u.premium && <i className="bi bi-star-fill" style={{ color: '#feda6a', marginLeft: '6px', fontSize: '0.75rem' }} title="Premium"></i>}
                         </Link>
                       </td>
-                      <td>
-                        {u.isOnline ? <span className="text-success fw-bold">Online</span> : <span className="text-secondary">Offline</span>}
+                      <td style={{ padding: '10px 12px' }}>
+                        {u.isOnline
+                          ? <span style={{ color: '#4ade80', fontWeight: '600', fontSize: '0.82rem' }}>● Online</span>
+                          : <span style={{ color: '#475569', fontSize: '0.82rem' }}>Offline</span>}
                       </td>
-                      <td className="d-none d-md-table-cell text-secondary">
-                        {u.knownLanguages.join(', ') || 'None'}
-                      </td>
-                      <td className="d-none d-md-table-cell text-secondary">
-                        {u.learnLanguages.join(', ') || 'None'}
-                      </td>
-                      <td>
-                        <div className="d-flex gap-2">
+                      <td style={{ padding: '10px 12px', color: '#64748b' }}>{u.knownLanguages.join(', ') || '—'}</td>
+                      <td style={{ padding: '10px 12px', color: '#64748b' }}>{u.learnLanguages.join(', ') || '—'}</td>
+                      <td style={{ padding: '10px 12px' }}>
+                        <div style={{ display: 'flex', gap: '0.5rem' }}>
                           <button
                             onClick={() => handleSelectiveCall(u._id)}
                             disabled={!u.isOnline || callStatus}
-                            className="btn btn-dark text-warning rounded-pill btn-sm"
+                            style={{ background: u.isOnline && !callStatus ? '#feda6a' : 'rgba(254,218,106,0.1)', color: u.isOnline && !callStatus ? '#1d1e22' : '#64748b', border: 'none', borderRadius: '8px', padding: '5px 12px', fontWeight: '600', fontSize: '0.8rem', cursor: u.isOnline && !callStatus ? 'pointer' : 'not-allowed' }}
                           >
-                            Call
+                            <i className="bi bi-telephone-fill" style={{ marginRight: '4px' }}></i>Call
                           </button>
                           <button
                             onClick={() => handleSendEmail(u._id, u.name)}
-                            disabled={!user?.premium}
-                            className="btn btn-dark text-warning rounded-pill btn-sm"
+                            style={{ background: 'rgba(99,179,237,0.12)', color: '#63b3ed', border: 'none', borderRadius: '8px', padding: '5px 12px', fontWeight: '600', fontSize: '0.8rem', cursor: 'pointer' }}
                           >
-                            Email
+                            <i className="bi bi-envelope-fill" style={{ marginRight: '4px' }}></i>Email
                           </button>
                         </div>
                       </td>
                     </tr>
                   ))}
+                  {filteredUsers.length === 0 && (
+                    <tr>
+                      <td colSpan="5" style={{ padding: '2rem', textAlign: 'center', color: '#475569' }}>No users found</td>
+                    </tr>
+                  )}
                 </tbody>
               </table>
             </div>
@@ -344,10 +358,7 @@ const Premium = () => {
         <EmailModal
           recipientId={selectedRecipient.id}
           recipientName={selectedRecipient.name}
-          onClose={() => {
-            setShowEmailModal(false);
-            setSelectedRecipient(null);
-          }}
+          onClose={() => { setShowEmailModal(false); setSelectedRecipient(null); }}
         />
       )}
     </div>

--- a/language-exchange-frontend/src/components/Profile.jsx
+++ b/language-exchange-frontend/src/components/Profile.jsx
@@ -1,321 +1,12 @@
-
-
-
-// import React, { useState } from 'react';
-// import { useSelector } from 'react-redux';
-// import { useNavigate, useParams } from 'react-router-dom';
-// import { useGetProfileQuery } from '../redux/services/userApi';
-// import { useUpdateProfileMutation } from '../redux/services/authApi';
-
-// const Profile = () => {
-//   const { user: authUser } = useSelector((state) => state.auth);
-//   const { userId } = useParams();
-//   console.log('Profile userId from params:', userId);
-//   console.log('Auth user ID:', authUser?._id);
-//   const { data, error, isLoading } = useGetProfileQuery(userId || authUser?._id);
-//   const [updateProfile] = useUpdateProfileMutation();
-//   const navigate = useNavigate();
-
-//   const [knownLanguage, setKnownLanguage] = useState('');
-//   const [learnLanguage, setLearnLanguage] = useState('');
-
-//   const isOwnProfile = !userId || userId === authUser?._id;
-//   const profileUser = data?.user || (isOwnProfile ? authUser : {});
-//   const avatarLetter = profileUser?.name?.charAt(0).toUpperCase() || 'U';
-
-//   const handleAddKnownLanguage = async () => {
-//     if (!isOwnProfile || !knownLanguage) return;
-//     try {
-//       const updatedKnownLanguages = [...(profileUser.knownLanguages || []), knownLanguage];
-//       await updateProfile({ knownLanguages: updatedKnownLanguages }).unwrap();
-//       setKnownLanguage('');
-//     } catch (err) {
-//       alert(err.data?.message || 'Failed to add language');
-//     }
-//   };
-
-//   const handleAddLearnLanguage = async () => {
-//     if (!isOwnProfile || !learnLanguage) return;
-//     try {
-//       const updatedLearnLanguages = [...(profileUser.learnLanguages || []), learnLanguage];
-//       await updateProfile({ learnLanguages: updatedLearnLanguages }).unwrap();
-//       setLearnLanguage('');
-//     } catch (err) {
-//       alert(err.data?.message || 'Failed to add language');
-//     }
-//   };
-
-//   if (isLoading) return <div style={{ color: '#393f4d', textAlign: 'center', marginTop: '50px' }}>Loading...</div>;
-//   if (error) return <div style={{ color: '#393f4d', textAlign: 'center', marginTop: '50px' }}>Error: {error.data?.message || 'Failed to load profile'}</div>;
-
-//   const languagesMissing = !profileUser.knownLanguages?.length || !profileUser.learnLanguages?.length;
-
-//   return (
-//     <div style={{ backgroundColor: '#FFFFFF', minHeight: '100vh', padding: '20px 0' }}>
-//       <h2 style={{
-//         color: '#1d1e22',
-//         marginBottom: '2rem',
-//         textAlign: 'center',
-//         fontWeight: 'bold',
-//         textShadow: '0 0 5px rgba(254, 218, 106, 0.3)',
-//         animation: 'fadeIn 0.5s ease-in',
-//       }}>
-//         {isOwnProfile ? 'Your Profile' : `${profileUser.name}'s Profile`}
-//       </h2>
-//       <div style={{
-//         maxWidth: '600px',
-//         margin: '0 auto',
-//         backgroundColor: '#d4d4dc',
-//         borderRadius: '15px',
-//         boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-//         padding: '2rem',
-//         animation: 'slideIn 0.5s ease-out',
-//       }}>
-//         <div style={{ display: 'flex', alignItems: 'center', marginBottom: '2rem', position: 'relative' }}>
-//           <div
-//             style={{
-//               backgroundColor: '#feda6a',
-//               color: '#1d1e22',
-//               width: '60px',
-//               height: '60px',
-//               fontSize: '2rem',
-//               fontWeight: 'bold',
-//               borderRadius: '50%',
-//               display: 'flex',
-//               alignItems: 'center',
-//               justifyContent: 'center',
-//               boxShadow: '0 0 8px rgba(254, 218, 106, 0.5)',
-//               transition: 'transform 0.3s ease, box-shadow 0.3s ease',
-//             }}
-//             onMouseOver={(e) => {
-//               e.target.style.transform = 'scale(1.1) rotate(5deg)';
-//               e.target.style.boxShadow = '0 0 12px rgba(254, 224, 143, 0.8)';
-//             }}
-//             onMouseOut={(e) => {
-//               e.target.style.transform = 'scale(1) rotate(0deg)';
-//               e.target.style.boxShadow = '0 0 8px rgba(254, 218, 106, 0.5)';
-//             }}
-//           >
-//             {avatarLetter}
-//           </div>
-//           {isOwnProfile && languagesMissing && (
-//             <span
-//               style={{
-//                 position: 'absolute',
-//                 top: '50px',
-//                 left: '20px',
-//                 backgroundColor: '#393f4d',
-//                 color: '#feda6a',
-//                 width: '18px',
-//                 height: '18px',
-//                 fontSize: '0.9rem',
-//                 lineHeight: '16px',
-//                 borderRadius: '50%',
-//                 textAlign: 'center',
-//                 boxShadow: '0 0 5px rgba(57, 63, 77, 0.5)',
-//               }}
-//             >
-//               !
-//             </span>
-//           )}
-//           <div style={{ marginLeft: '1rem' }}>
-//             <h3 style={{ color: '#1d1e22', margin: 0 }}>{profileUser.name || 'No Name'}</h3>
-//             <p style={{ color: '#393f4d', margin: 0 }}>{profileUser.email || 'No Email'}</p>
-//           </div>
-//         </div>
-
-//         {isOwnProfile && languagesMissing && (
-//           <div style={{
-//             backgroundColor: '#feda6a',
-//             color: '#1d1e22',
-//             padding: '1rem',
-//             borderRadius: '10px',
-//             marginBottom: '1.5rem',
-//             boxShadow: '0 2px 6px rgba(254, 218, 106, 0.4)',
-//           }}>
-//             Please add languages you know and want to learn to complete your profile!
-//           </div>
-//         )}
-
-//         <div style={{ marginBottom: '1.5rem' }}>
-//           <h5 style={{ color: '#1d1e22', fontWeight: '600' }}>Known Languages</h5>
-//           {profileUser.knownLanguages?.length > 0 ? (
-//             <ul style={{ listStyle: 'none', padding: 0 }}>
-//               {profileUser.knownLanguages.map((lang, index) => (
-//                 <li key={index} style={{ color: '#393f4d', padding: '0.5rem 0' }}>{lang}</li>
-//               ))}
-//             </ul>
-//           ) : (
-//             <p style={{ color: '#393f4d' }}>No languages added yet.</p>
-//           )}
-//           {isOwnProfile && (
-//             <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', maxWidth: '300px' }}>
-//               <input
-//                 type="text"
-//                 placeholder="Add a language you know"
-//                 value={knownLanguage}
-//                 onChange={(e) => setKnownLanguage(e.target.value)}
-//                 style={{
-//                   borderColor: '#d4d4dc',
-//                   color: '#393f4d',
-//                   borderRadius: '8px',
-//                   padding: '0.5rem 1rem',
-//                   flex: 1,
-//                   transition: 'border-color 0.3s ease, box-shadow 0.3s ease',
-//                 }}
-//                 onFocus={(e) => {
-//                   e.target.style.borderColor = '#1d1e22';
-//                   e.target.style.boxShadow = '0 0 5px rgba(29, 30, 34, 0.5)';
-//                 }}
-//                 onBlur={(e) => {
-//                   e.target.style.borderColor = '#d4d4dc';
-//                   e.target.style.boxShadow = 'none';
-//                 }}
-//               />
-//               <button
-//                 onClick={handleAddKnownLanguage}
-//                 style={{
-//                   backgroundColor: '#1d1e22',
-//                   color: '#feda6a',
-//                   border: 'none',
-//                   padding: '0.75rem 1.5rem',
-//                   borderRadius: '8px',
-//                   transition: 'background-color 0.3s ease, transform 0.3s ease',
-//                 }}
-//                 onMouseOver={(e) => {
-//                   e.target.style.backgroundColor = '#151618';
-//                   e.target.style.transform = 'scale(1.05)';
-//                 }}
-//                 onMouseOut={(e) => {
-//                   e.target.style.backgroundColor = '#1d1e22';
-//                   e.target.style.transform = 'scale(1)';
-//                 }}
-//               >
-//                 Add
-//               </button>
-//             </div>
-//           )}
-//         </div>
-
-//         <div style={{ marginBottom: '1.5rem' }}>
-//           <h5 style={{ color: '#1d1e22', fontWeight: '600' }}>Languages to Learn</h5>
-//           {profileUser.learnLanguages?.length > 0 ? (
-//             <ul style={{ listStyle: 'none', padding: 0 }}>
-//               {profileUser.learnLanguages.map((lang, index) => (
-//                 <li key={index} style={{ color: '#393f4d', padding: '0.5rem 0' }}>{lang}</li>
-//               ))}
-//             </ul>
-//           ) : (
-//             <p style={{ color: '#393f4d' }}>No languages added yet.</p>
-//           )}
-//           {isOwnProfile && (
-//             <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', maxWidth: '300px' }}>
-//               <input
-//                 type="text"
-//                 placeholder="Add a language to learn"
-//                 value={learnLanguage}
-//                 onChange={(e) => setLearnLanguage(e.target.value)}
-//                 style={{
-//                   borderColor: '#d4d4dc',
-//                   color: '#393f4d',
-//                   borderRadius: '8px',
-//                   padding: '0.5rem 1rem',
-//                   flex: 1,
-//                   transition: 'border-color 0.3s ease, box-shadow 0.3s ease',
-//                 }}
-//                 onFocus={(e) => {
-//                   e.target.style.borderColor = '#1d1e22';
-//                   e.target.style.boxShadow = '0 0 5px rgba(29, 30, 34, 0.5)';
-//                 }}
-//                 onBlur={(e) => {
-//                   e.target.style.borderColor = '#d4d4dc';
-//                   e.target.style.boxShadow = 'none';
-//                 }}
-//               />
-//               <button
-//                 onClick={handleAddLearnLanguage}
-//                 style={{
-//                   backgroundColor: '#1d1e22',
-//                   color: '#feda6a',
-//                   border: 'none',
-//                   padding: '0.75rem 1.5rem',
-//                   borderRadius: '8px',
-//                   transition: 'background-color 0.3s ease, transform 0.3s ease',
-//                 }}
-//                 onMouseOver={(e) => {
-//                   e.target.style.backgroundColor = '#151618';
-//                   e.target.style.transform = 'scale(1.05)';
-//                 }}
-//                 onMouseOut={(e) => {
-//                   e.target.style.backgroundColor = '#1d1e22';
-//                   e.target.style.transform = 'scale(1)';
-//                 }}
-//               >
-//                 Add
-//               </button>
-//             </div>
-//           )}
-//         </div>
-
-//         {isOwnProfile && (
-//           <button
-//             onClick={() => navigate('/update-profile')}
-//             style={{
-//               backgroundColor: '#feda6a',
-//               color: '#1d1e22',
-//               border: 'none',
-//               padding: '0.75rem 2rem',
-//               borderRadius: '20px',
-//               fontWeight: 'bold',
-//               boxShadow: '0 2px 6px rgba(254, 218, 106, 0.4)',
-//               transition: 'background-color 0.3s ease, transform 0.3s ease',
-//             }}
-//             onMouseOver={(e) => {
-//               e.target.style.backgroundColor = '#fee08f';
-//               e.target.style.transform = 'scale(1.05)';
-//             }}
-//             onMouseOut={(e) => {
-//               e.target.style.backgroundColor = '#feda6a';
-//               e.target.style.transform = 'scale(1)';
-//             }}
-//           >
-//             Update Info
-//           </button>
-//         )}
-//       </div>
-
-//       <style>
-//         {`
-//           @keyframes slideIn {
-//             from { transform: translateY(20px); opacity: 0; }
-//             to { transform: translateY(0); opacity: 1; }
-//           }
-//           @keyframes fadeIn {
-//             from { opacity: 0; }
-//             to { opacity: 1; }
-//           }
-//         `}
-//       </style>
-//     </div>
-//   );
-// };
-
-// export default Profile;
-
-
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-// --- useGetProfileQuery is correct, but we'll change where we get the update mutation ---
 import { useGetProfileQuery, useUpdateProfileMutation } from '../redux/services/userApi';
 
 const Profile = () => {
   const { user: authUser } = useSelector((state) => state.auth);
   const { userId } = useParams();
-  console.log('Profile userId from params:', userId);
-  console.log('Auth user ID:', authUser?._id);
   const { data, error, isLoading } = useGetProfileQuery(userId || authUser?._id);
-  // --- This hook now comes from userApi, which correctly invalidates this page's query ---
   const [updateProfile] = useUpdateProfileMutation();
   const navigate = useNavigate();
 
@@ -327,10 +18,11 @@ const Profile = () => {
   const avatarLetter = profileUser?.name?.charAt(0).toUpperCase() || 'U';
 
   const handleAddKnownLanguage = async () => {
-    if (!isOwnProfile || !knownLanguage) return;
+    const normalized = knownLanguage.trim().toLowerCase();
+    if (!isOwnProfile || !normalized) return;
     try {
-      const updatedKnownLanguages = [...(profileUser.knownLanguages || []), knownLanguage];
-      await updateProfile({ knownLanguages: updatedKnownLanguages }).unwrap();
+      const updated = [...(profileUser.knownLanguages || []), normalized];
+      await updateProfile({ knownLanguages: updated }).unwrap();
       setKnownLanguage('');
     } catch (err) {
       alert(err.data?.message || 'Failed to add language');
@@ -338,267 +30,145 @@ const Profile = () => {
   };
 
   const handleAddLearnLanguage = async () => {
-    if (!isOwnProfile || !learnLanguage) return;
+    const normalized = learnLanguage.trim().toLowerCase();
+    if (!isOwnProfile || !normalized) return;
     try {
-      const updatedLearnLanguages = [...(profileUser.learnLanguages || []), learnLanguage];
-      await updateProfile({ learnLanguages: updatedLearnLanguages }).unwrap();
+      const updated = [...(profileUser.learnLanguages || []), normalized];
+      await updateProfile({ learnLanguages: updated }).unwrap();
       setLearnLanguage('');
     } catch (err) {
       alert(err.data?.message || 'Failed to add language');
     }
   };
 
-  if (isLoading) return <div style={{ color: '#393f4d', textAlign: 'center', marginTop: '50px' }}>Loading...</div>;
-  if (error) return <div style={{ color: '#393f4d', textAlign: 'center', marginTop: '50px' }}>Error: {error.data?.message || 'Failed to load profile'}</div>;
+  if (isLoading) return <div style={{ color: '#94a3b8', textAlign: 'center', marginTop: '80px' }}>Loading…</div>;
+  if (error) return <div style={{ color: '#fc8181', textAlign: 'center', marginTop: '80px' }}>Error: {error.data?.message || 'Failed to load profile'}</div>;
 
-  const languagesMissing = !profileUser.knownLanguages?.length || !profileUser.learnLanguages?.length;
+  const languagesMissing = isOwnProfile && (!profileUser.knownLanguages?.length || !profileUser.learnLanguages?.length);
+
+  const inputStyle = {
+    flex: 1,
+    background: 'rgba(255,255,255,0.06)',
+    border: '1px solid rgba(255,255,255,0.12)',
+    color: '#f1f5f9',
+    borderRadius: '10px',
+    padding: '8px 12px',
+    fontSize: '0.88rem',
+    outline: 'none',
+  };
+
+  const addBtnStyle = {
+    background: '#feda6a',
+    color: '#1d1e22',
+    border: 'none',
+    borderRadius: '10px',
+    padding: '8px 16px',
+    fontWeight: '700',
+    fontSize: '0.82rem',
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+  };
 
   return (
-    <div style={{ backgroundColor: '#FFFFFF', minHeight: '100vh', padding: '20px 0' }}>
-      <h2 style={{
-        color: '#1d1e22',
-        marginBottom: '2rem',
-        textAlign: 'center',
-        fontWeight: 'bold',
-        textShadow: '0 0 5px rgba(254, 218, 106, 0.3)',
-        animation: 'fadeIn 0.5s ease-in',
-      }}>
-        {isOwnProfile ? 'Your Profile' : `${profileUser.name}'s Profile`}
-      </h2>
-      <div style={{
-        maxWidth: '600px',
-        margin: '0 auto',
-        backgroundColor: '#d4d4dc',
-        borderRadius: '15px',
-        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
-        padding: '2rem',
-        animation: 'slideIn 0.5s ease-out',
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', marginBottom: '2rem', position: 'relative' }}>
-          <div
-            style={{
-              backgroundColor: '#feda6a',
-              color: '#1d1e22',
-              width: '60px',
-              height: '60px',
-              fontSize: '2rem',
-              fontWeight: 'bold',
-              borderRadius: '50%',
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              boxShadow: '0 0 8px rgba(254, 218, 106, 0.5)',
-              transition: 'transform 0.3s ease, box-shadow 0.3s ease',
-            }}
-            onMouseOver={(e) => {
-              e.target.style.transform = 'scale(1.1) rotate(5deg)';
-              e.target.style.boxShadow = '0 0 12px rgba(254, 224, 143, 0.8)';
-            }}
-            onMouseOut={(e) => {
-              e.target.style.transform = 'scale(1) rotate(0deg)';
-              e.target.style.boxShadow = '0 0 8px rgba(254, 218, 106, 0.5)';
-            }}
-          >
+    <div style={{ background: '#0f1117', minHeight: '100vh', padding: '3rem 1rem', fontFamily: "'Inter', sans-serif" }}>
+      <div style={{ maxWidth: '640px', margin: '0 auto' }}>
+
+        {/* Header card */}
+        <div style={{ background: 'rgba(22,25,35,0.92)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: '20px', padding: '2rem', backdropFilter: 'blur(12px)', marginBottom: '1.5rem', display: 'flex', alignItems: 'center', gap: '1.2rem', flexWrap: 'wrap' }}>
+          <div style={{ width: '64px', height: '64px', borderRadius: '50%', background: '#feda6a', color: '#1d1e22', fontSize: '1.8rem', fontWeight: '800', display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0, position: 'relative' }}>
             {avatarLetter}
+            {languagesMissing && (
+              <span style={{ position: 'absolute', top: 0, right: 0, width: '18px', height: '18px', background: '#e53e3e', color: '#fff', borderRadius: '50%', fontSize: '0.65rem', fontWeight: '800', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>!</span>
+            )}
           </div>
-          {isOwnProfile && languagesMissing && (
-            <span
-              style={{
-                position: 'absolute',
-                top: '50px',
-                left: '20px',
-                backgroundColor: '#393f4d',
-                color: '#feda6a',
-                width: '18px',
-                height: '18px',
-                fontSize: '0.9rem',
-                lineHeight: '16px',
-                borderRadius: '50%',
-                textAlign: 'center',
-                boxShadow: '0 0 5px rgba(57, 63, 77, 0.5)',
-              }}
+          <div style={{ flex: 1 }}>
+            <h2 style={{ color: '#f1f5f9', fontWeight: '800', margin: '0 0 2px', fontSize: '1.4rem' }}>
+              {profileUser.name || 'Profile'}
+            </h2>
+            <p style={{ color: '#64748b', margin: 0, fontSize: '0.88rem' }}>{profileUser.email || ''}</p>
+            {profileUser.premium && (
+              <span style={{ background: 'rgba(254,218,106,0.12)', color: '#feda6a', borderRadius: '20px', padding: '2px 10px', fontSize: '0.75rem', fontWeight: '700', marginTop: '4px', display: 'inline-block' }}>
+                <i className="bi bi-star-fill" style={{ marginRight: '4px' }}></i>Premium
+              </span>
+            )}
+          </div>
+          {isOwnProfile && (
+            <button
+              onClick={() => navigate('/update-profile')}
+              style={{ background: 'rgba(254,218,106,0.12)', color: '#feda6a', border: '1px solid rgba(254,218,106,0.2)', borderRadius: '10px', padding: '8px 16px', fontWeight: '600', fontSize: '0.82rem', cursor: 'pointer', whiteSpace: 'nowrap' }}
             >
-              !
-            </span>
+              <i className="bi bi-pencil-fill" style={{ marginRight: '6px' }}></i>Edit
+            </button>
           )}
-          <div style={{ marginLeft: '1rem' }}>
-            <h3 style={{ color: '#1d1e22', margin: 0 }}>{profileUser.name || 'No Name'}</h3>
-            <p style={{ color: '#393f4d', margin: 0 }}>{profileUser.email || 'No Email'}</p>
-          </div>
         </div>
 
-        {isOwnProfile && languagesMissing && (
-          <div style={{
-            backgroundColor: '#feda6a',
-            color: '#1d1e22',
-            padding: '1rem',
-            borderRadius: '10px',
-            marginBottom: '1.5rem',
-            boxShadow: '0 2px 6px rgba(254, 218, 106, 0.4)',
-          }}>
-            Please add languages you know and want to learn to complete your profile!
+        {/* Warning banner */}
+        {languagesMissing && (
+          <div style={{ background: 'rgba(254,218,106,0.1)', border: '1px solid rgba(254,218,106,0.25)', borderRadius: '12px', padding: '0.9rem 1.2rem', marginBottom: '1.5rem', color: '#feda6a', fontSize: '0.88rem', display: 'flex', gap: '10px', alignItems: 'flex-start' }}>
+            <i className="bi bi-exclamation-triangle-fill" style={{ marginTop: '2px' }}></i>
+            Add languages you know and want to learn to start getting matched on calls!
           </div>
         )}
 
-        <div style={{ marginBottom: '1.5rem' }}>
-          <h5 style={{ color: '#1d1e22', fontWeight: '600' }}>Known Languages</h5>
+        {/* Known Languages */}
+        <div style={{ background: 'rgba(22,25,35,0.85)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: '16px', padding: '1.5rem', marginBottom: '1.2rem' }}>
+          <h5 style={{ color: '#f1f5f9', fontWeight: '700', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <i className="bi bi-chat-quote-fill" style={{ color: '#feda6a' }}></i>Known Languages
+          </h5>
           {profileUser.knownLanguages?.length > 0 ? (
-            <ul style={{ listStyle: 'none', padding: 0 }}>
-              {profileUser.knownLanguages.map((lang, index) => (
-                <li key={index} style={{ color: '#393f4d', padding: '0.5rem 0' }}>{lang}</li>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1rem' }}>
+              {profileUser.knownLanguages.map((lang, i) => (
+                <span key={i} style={{ background: 'rgba(254,218,106,0.1)', color: '#feda6a', borderRadius: '20px', padding: '4px 14px', fontSize: '0.82rem', fontWeight: '600' }}>{lang}</span>
               ))}
-            </ul>
+            </div>
           ) : (
-            <p style={{ color: '#393f4d' }}>No languages added yet.</p>
+            <p style={{ color: '#475569', fontSize: '0.88rem', marginBottom: '1rem' }}>No languages added yet.</p>
           )}
           {isOwnProfile && (
-            <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', maxWidth: '300px' }}>
+            <div style={{ display: 'flex', gap: '0.6rem', alignItems: 'center' }}>
               <input
                 type="text"
-                placeholder="Add a language you know"
+                placeholder="e.g., english"
                 value={knownLanguage}
                 onChange={(e) => setKnownLanguage(e.target.value)}
-                style={{
-                  borderColor: '#d4d4dc',
-                  color: '#393f4d',
-                  borderRadius: '8px',
-                  padding: '0.5rem 1rem',
-                  flex: 1,
-                  transition: 'border-color 0.3s ease, box-shadow 0.3s ease',
-                }}
-                onFocus={(e) => {
-                  e.target.style.borderColor = '#1d1e22';
-                  e.target.style.boxShadow = '0 0 5px rgba(29, 30, 34, 0.5)';
-                }}
-                onBlur={(e) => {
-                  e.target.style.borderColor = '#d4d4dc';
-                  e.target.style.boxShadow = 'none';
-                }}
+                onKeyDown={(e) => e.key === 'Enter' && handleAddKnownLanguage()}
+                style={inputStyle}
               />
-              <button
-                onClick={handleAddKnownLanguage}
-                style={{
-                  backgroundColor: '#1d1e22',
-                  color: '#feda6a',
-                  border: 'none',
-                  padding: '0.75rem 1.5rem',
-                  borderRadius: '8px',
-                  transition: 'background-color 0.3s ease, transform 0.3s ease',
-                }}
-                onMouseOver={(e) => {
-                  e.target.style.backgroundColor = '#151618';
-                  e.target.style.transform = 'scale(1.05)';
-                }}
-                onMouseOut={(e) => {
-                  e.target.style.backgroundColor = '#1d1e22';
-                  e.target.style.transform = 'scale(1)';
-                }}
-              >
-                Add
-              </button>
+              <button onClick={handleAddKnownLanguage} style={addBtnStyle}>Add</button>
             </div>
           )}
         </div>
 
-        <div style={{ marginBottom: '1.5rem' }}>
-          <h5 style={{ color: '#1d1e22', fontWeight: '600' }}>Languages to Learn</h5>
+        {/* Learning Languages */}
+        <div style={{ background: 'rgba(22,25,35,0.85)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: '16px', padding: '1.5rem' }}>
+          <h5 style={{ color: '#f1f5f9', fontWeight: '700', marginBottom: '1rem', display: 'flex', alignItems: 'center', gap: '8px' }}>
+            <i className="bi bi-translate" style={{ color: '#63b3ed' }}></i>Learning Languages
+          </h5>
           {profileUser.learnLanguages?.length > 0 ? (
-            <ul style={{ listStyle: 'none', padding: 0 }}>
-              {profileUser.learnLanguages.map((lang, index) => (
-                <li key={index} style={{ color: '#393f4d', padding: '0.5rem 0' }}>{lang}</li>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5rem', marginBottom: '1rem' }}>
+              {profileUser.learnLanguages.map((lang, i) => (
+                <span key={i} style={{ background: 'rgba(99,179,237,0.1)', color: '#63b3ed', borderRadius: '20px', padding: '4px 14px', fontSize: '0.82rem', fontWeight: '600' }}>{lang}</span>
               ))}
-            </ul>
+            </div>
           ) : (
-            <p style={{ color: '#393f4d' }}>No languages added yet.</p>
+            <p style={{ color: '#475569', fontSize: '0.88rem', marginBottom: '1rem' }}>No languages added yet.</p>
           )}
           {isOwnProfile && (
-            <div style={{ display: 'flex', gap: '1rem', alignItems: 'center', maxWidth: '300px' }}>
+            <div style={{ display: 'flex', gap: '0.6rem', alignItems: 'center' }}>
               <input
                 type="text"
-                placeholder="Add a language to learn"
+                placeholder="e.g., spanish"
                 value={learnLanguage}
                 onChange={(e) => setLearnLanguage(e.target.value)}
-                style={{
-                  borderColor: '#d4d4dc',
-                  color: '#393f4d',
-                  borderRadius: '8px',
-                  padding: '0.5rem 1rem',
-                  flex: 1,
-                  transition: 'border-color 0.3s ease, box-shadow 0.3s ease',
-                }}
-                onFocus={(e) => {
-                  e.target.style.borderColor = '#1d1e22';
-                  e.target.style.boxShadow = '0 0 5px rgba(29, 30, 34, 0.5)';
-                }}
-                onBlur={(e) => {
-                  e.target.style.borderColor = '#d4d4dc';
-                  e.target.style.boxShadow = 'none';
-                }}
+                onKeyDown={(e) => e.key === 'Enter' && handleAddLearnLanguage()}
+                style={inputStyle}
               />
-              <button
-                onClick={handleAddLearnLanguage}
-                style={{
-                  backgroundColor: '#1d1e22',
-                  color: '#feda6a',
-                  border: 'none',
-                  padding: '0.75rem 1.5rem',
-                  borderRadius: '8px',
-                  transition: 'background-color 0.3s ease, transform 0.3s ease',
-                }}
-                onMouseOver={(e) => {
-                  e.target.style.backgroundColor = '#151618';
-                  e.target.style.transform = 'scale(1.05)';
-                }}
-                onMouseOut={(e) => {
-                  e.target.style.backgroundColor = '#1d1e22';
-                  e.target.style.transform = 'scale(1)';
-                }}
-              >
-                Add
-              </button>
+              <button onClick={handleAddLearnLanguage} style={addBtnStyle}>Add</button>
             </div>
           )}
         </div>
 
-        {isOwnProfile && (
-          <button
-            onClick={() => navigate('/update-profile')}
-            style={{
-              backgroundColor: '#feda6a',
-              color: '#1d1e22',
-              border: 'none',
-              padding: '0.75rem 2rem',
-              borderRadius: '20px',
-              fontWeight: 'bold',
-              boxShadow: '0 2px 6px rgba(254, 218, 106, 0.4)',
-              transition: 'background-color 0.3s ease, transform 0.3s ease',
-            }}
-            onMouseOver={(e) => {
-              e.target.style.backgroundColor = '#fee08f';
-              e.target.style.transform = 'scale(1.05)';
-            }}
-            onMouseOut={(e) => {
-              e.target.style.backgroundColor = '#feda6a';
-              e.target.style.transform = 'scale(1)';
-            }}
-          >
-            Update Info
-          </button>
-        )}
       </div>
-
-      <style>
-        {`
-          @keyframes slideIn {
-            from { transform: translateY(20px); opacity: 0; }
-            to { transform: translateY(0); opacity: 1; }
-          }
-          @keyframes fadeIn {
-            from { opacity: 0; }
-            to { opacity: 1; }
-          }
-        `}
-      </style>
     </div>
   );
 };

--- a/language-exchange-frontend/src/components/ResetPassword.jsx
+++ b/language-exchange-frontend/src/components/ResetPassword.jsx
@@ -1,12 +1,24 @@
-
-
 import React, { useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useResetPasswordMutation } from '../redux/services/authApi';
+import { toast } from 'react-toastify';
+
+const inputStyle = {
+  width: '100%',
+  padding: '10px 14px',
+  borderRadius: '10px',
+  border: '1px solid rgba(255,255,255,0.12)',
+  background: 'rgba(255,255,255,0.06)',
+  color: '#f1f5f9',
+  fontSize: '0.9rem',
+  outline: 'none',
+  transition: 'border-color 0.2s, box-shadow 0.2s',
+};
 
 const ResetPassword = () => {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
+  const [focused, setFocused] = useState('');
   const { token } = useParams();
   const navigate = useNavigate();
   const [resetPassword, { isLoading }] = useResetPasswordMutation();
@@ -14,158 +26,73 @@ const ResetPassword = () => {
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (password !== confirmPassword) {
-      alert("Passwords don't match");
+      toast.error("Passwords don't match");
       return;
     }
-
     try {
       await resetPassword({ token, newPassword: password }).unwrap();
-      alert('Password reset successfully');
+      toast.success('Password reset successfully');
       navigate('/login');
     } catch (err) {
-      alert(err.data?.message || 'Failed to reset password');
+      toast.error(err.data?.message || 'Failed to reset password');
     }
   };
 
+  const focusStyle = { borderColor: 'rgba(254,218,106,0.55)', boxShadow: '0 0 0 3px rgba(254,218,106,0.12)' };
+
   return (
-    <div style={{
-      backgroundColor: '#FFFFFF',
-      minHeight: '100vh',
-      display: 'flex',
-      alignItems: 'center',
-      justifyContent: 'center',
-      padding: '20px',
-    }}>
-      <div style={{
-        maxWidth: '400px',
-        width: '100%',
-        background: 'linear-gradient(135deg, #d4d4dc 0%, #FFFFFF 100%)',
-        borderRadius: '15px',
-        boxShadow: '0 4px 20px rgba(0, 0, 0, 0.3)',
-        padding: '2rem',
-        animation: 'slideIn 0.5s ease-out',
-      }}>
-        <h2 style={{
-          color: '#1d1e22',
-          fontWeight: 'bold',
-          textShadow: '0 0 5px rgba(254, 218, 106, 0.3)',
-          textAlign: 'center',
-          marginBottom: '2rem',
-        }}>
-          Reset Password
-        </h2>
+    <div style={{ background: '#0f1117', minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: '20px', fontFamily: "'Inter', sans-serif" }}>
+      <div style={{ maxWidth: '420px', width: '100%', background: 'rgba(18,20,30,0.92)', border: '1px solid rgba(254,218,106,0.18)', borderRadius: '20px', boxShadow: '0 24px 64px rgba(0,0,0,0.6)', backdropFilter: 'blur(16px)', padding: '2.5rem 2rem', animation: 'slideUp 0.5s ease-out' }}>
+
+        <div style={{ width: '56px', height: '56px', borderRadius: '16px', background: 'rgba(254,218,106,0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center', margin: '0 auto 1.2rem' }}>
+          <i className="bi bi-key-fill" style={{ fontSize: '1.6rem', color: '#feda6a' }}></i>
+        </div>
+
+        <h2 style={{ color: '#f1f5f9', fontWeight: '800', textAlign: 'center', marginBottom: '0.4rem', fontSize: '1.5rem' }}>Reset Password</h2>
+        <p style={{ color: '#64748b', textAlign: 'center', fontSize: '0.88rem', marginBottom: '2rem' }}>Enter your new password below</p>
+
         <form onSubmit={handleSubmit}>
-          <div style={{ marginBottom: '1.5rem' }}>
-            <label htmlFor="password" style={{
-              color: '#393f4d',
-              fontWeight: '500',
-              display: 'block',
-              marginBottom: '0.5rem',
-            }}>
-              New Password
-            </label>
+          <div style={{ marginBottom: '1.2rem' }}>
+            <label style={{ color: '#94a3b8', fontSize: '0.82rem', fontWeight: '600', display: 'block', marginBottom: '6px' }}>New Password</label>
             <input
               type="password"
-              id="password"
               placeholder="Enter new password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               required
-              style={{
-                width: '100%',
-                padding: '0.75rem 1rem',
-                borderRadius: '8px',
-                border: '1px solid #d4d4dc',
-                color: '#393f4d',
-                backgroundColor: '#FFFFFF',
-                transition: 'border-color 0.3s ease, box-shadow 0.3s ease',
-              }}
-              onFocus={(e) => {
-                e.target.style.borderColor = '#1d1e22';
-                e.target.style.boxShadow = '0 0 5px rgba(29, 30, 34, 0.5)';
-              }}
-              onBlur={(e) => {
-                e.target.style.borderColor = '#d4d4dc';
-                e.target.style.boxShadow = 'none';
-              }}
+              style={{ ...inputStyle, ...(focused === 'pw' ? focusStyle : {}) }}
+              onFocus={() => setFocused('pw')}
+              onBlur={() => setFocused('')}
             />
           </div>
           <div style={{ marginBottom: '2rem' }}>
-            <label htmlFor="confirmPassword" style={{
-              color: '#393f4d',
-              fontWeight: '500',
-              display: 'block',
-              marginBottom: '0.5rem',
-            }}>
-              Confirm Password
-            </label>
+            <label style={{ color: '#94a3b8', fontSize: '0.82rem', fontWeight: '600', display: 'block', marginBottom: '6px' }}>Confirm Password</label>
             <input
               type="password"
-              id="confirmPassword" // Fixed ID to match label
               placeholder="Confirm new password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               required
-              style={{
-                width: '100%',
-                padding: '0.75rem 1rem',
-                borderRadius: '8px',
-                border: '1px solid #d4d4dc',
-                color: '#393f4d',
-                backgroundColor: '#FFFFFF',
-                transition: 'border-color 0.3s ease, box-shadow 0.3s ease',
-              }}
-              onFocus={(e) => {
-                e.target.style.borderColor = '#1d1e22';
-                e.target.style.boxShadow = '0 0 5px rgba(29, 30, 34, 0.5)';
-              }}
-              onBlur={(e) => {
-                e.target.style.borderColor = '#d4d4dc';
-                e.target.style.boxShadow = 'none';
-              }}
+              style={{ ...inputStyle, ...(focused === 'cpw' ? focusStyle : {}) }}
+              onFocus={() => setFocused('cpw')}
+              onBlur={() => setFocused('')}
             />
           </div>
           <button
             type="submit"
             disabled={isLoading}
-            style={{
-              backgroundColor: '#feda6a',
-              color: '#1d1e22',
-              border: 'none',
-              width: '100%',
-              padding: '0.75rem',
-              borderRadius: '20px',
-              fontWeight: 'bold',
-              boxShadow: '0 2px 6px rgba(254, 218, 106, 0.4)',
-              transition: 'background-color 0.3s ease, transform 0.3s ease',
-              opacity: isLoading ? 0.6 : 1,
-            }}
-            onMouseOver={(e) => {
-              if (!isLoading) {
-                e.target.style.backgroundColor = '#fee08f';
-                e.target.style.transform = 'scale(1.05)';
-              }
-            }}
-            onMouseOut={(e) => {
-              if (!isLoading) {
-                e.target.style.backgroundColor = '#feda6a';
-                e.target.style.transform = 'scale(1)';
-              }
-            }}
+            style={{ width: '100%', padding: '11px', borderRadius: '12px', border: 'none', background: isLoading ? 'rgba(254,218,106,0.4)' : '#feda6a', color: '#1d1e22', fontWeight: '700', fontSize: '0.95rem', cursor: isLoading ? 'not-allowed' : 'pointer', transition: 'background 0.2s, transform 0.15s' }}
+            onMouseOver={(e) => { if (!isLoading) e.target.style.background = '#fdc53f'; }}
+            onMouseOut={(e) => { if (!isLoading) e.target.style.background = '#feda6a'; }}
           >
-            {isLoading ? 'Resetting...' : 'Change Password'}
+            {isLoading ? 'Resetting…' : 'Change Password'}
           </button>
         </form>
       </div>
 
-      <style>
-        {`
-          @keyframes slideIn {
-            from { transform: translateY(20px); opacity: 0; }
-            to { transform: translateY(0); opacity: 1; }
-          }
-        `}
-      </style>
+      <style>{`
+        @keyframes slideUp { from { transform: translateY(24px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+      `}</style>
     </div>
   );
 };

--- a/language-exchange-frontend/src/components/Store.jsx
+++ b/language-exchange-frontend/src/components/Store.jsx
@@ -1566,275 +1566,155 @@ const Store = () => {
 
   if (!isAuthenticated) {
     return (
-      <div style={{ color: '#393f4d', textAlign: 'center', marginTop: '50px', fontSize: '1.2rem' }}>
+      <div style={{ color: '#94a3b8', textAlign: 'center', marginTop: '80px', fontSize: '1.1rem' }}>
         Please log in to access the store.
       </div>
     );
   }
 
+  const cardBase = {
+    background: 'rgba(22, 25, 35, 0.85)',
+    border: '1px solid rgba(255,255,255,0.07)',
+    borderRadius: '20px',
+    padding: '2rem 1.5rem',
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    textAlign: 'center',
+    transition: 'transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s',
+    backdropFilter: 'blur(8px)',
+  };
+
+  const btnBase = {
+    background: '#feda6a',
+    color: '#1d1e22',
+    border: 'none',
+    width: '100%',
+    padding: '0.8rem',
+    borderRadius: '12px',
+    fontSize: '0.95rem',
+    fontWeight: '700',
+    cursor: 'pointer',
+    transition: 'background 0.2s, transform 0.15s',
+    marginTop: 'auto',
+  };
+
   return (
-    <div style={{
-      background: 'linear-gradient(135deg, #f5f7fa 0%, #c3cfe2 100%)',
-      minHeight: '100vh',
-      padding: '40px 20px',
-      fontFamily: "'Poppins', sans-serif",
-    }}>
-      <h2 style={{
-        color: '#1d1e22',
-        textAlign: 'center',
-        marginBottom: '3rem',
-        fontSize: '2.5rem',
-        fontWeight: '700',
-        textShadow: '0 2px 4px rgba(254, 218, 106, 0.3)',
-        animation: 'fadeIn 0.8s ease-in',
-      }}>
+    <div style={{ background: '#0f1117', minHeight: '100vh', padding: '60px 20px', fontFamily: "'Inter', sans-serif" }}>
+      <h2 style={{ color: '#f1f5f9', textAlign: 'center', marginBottom: '0.5rem', fontSize: '2rem', fontWeight: '800' }}>
         Language Exchange Store
       </h2>
-      <div style={{
-        maxWidth: '1200px',
-        margin: '0 auto',
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
-        gap: '2rem',
-        padding: '0 1rem',
-      }}>
+      <p style={{ color: '#64748b', textAlign: 'center', marginBottom: '3rem', fontSize: '1rem' }}>
+        Power up your learning journey
+      </p>
+
+      {/* Token balance pill */}
+      <div style={{ display: 'flex', justifyContent: 'center', gap: '1rem', marginBottom: '3rem', flexWrap: 'wrap' }}>
+        <span style={{ background: 'rgba(254,218,106,0.12)', color: '#feda6a', borderRadius: '20px', padding: '6px 18px', fontSize: '0.88rem', fontWeight: '600' }}>
+          <i className="bi bi-lightning-fill" style={{ marginRight: '6px' }}></i>
+          Power Tokens: {user?.powerTokens ?? 0}
+        </span>
+        <span style={{ background: 'rgba(99,179,237,0.12)', color: '#63b3ed', borderRadius: '20px', padding: '6px 18px', fontSize: '0.88rem', fontWeight: '600' }}>
+          <i className="bi bi-coin" style={{ marginRight: '6px' }}></i>
+          Coins: {user?.coinTokens ?? 0}
+        </span>
+      </div>
+
+      <div style={{ maxWidth: '1100px', margin: '0 auto', display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))', gap: '1.5rem', padding: '0 1rem' }}>
+
         {/* Power Tokens */}
-        <div style={{
-          backgroundColor: '#ffffff',
-          borderRadius: '20px',
-          padding: '2rem',
-          boxShadow: '0 8px 24px rgba(0, 0, 0, 0.1)',
-          transition: 'transform 0.3s ease, box-shadow 0.3s ease',
-          animation: 'slideIn 0.5s ease-out',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          textAlign: 'center',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = 'translateY(-10px)';
-          e.currentTarget.style.boxShadow = '0 12px 32px rgba(254, 218, 106, 0.3)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = 'translateY(0)';
-          e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.1)';
-        }}
+        <div
+          style={cardBase}
+          onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-8px)'; e.currentTarget.style.boxShadow = '0 16px 48px rgba(254,218,106,0.12)'; e.currentTarget.style.borderColor = 'rgba(254,218,106,0.25)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.07)'; }}
         >
-          <img
-            src={powerTokenImg}
-            alt="Power Token"
-            style={{ width: '80px', height: '80px', marginBottom: '1rem' }}
-          />
-          <h5 style={{
-            color: '#1d1e22',
-            fontSize: '1.5rem',
-            fontWeight: '600',
-            marginBottom: '1rem',
-          }}>
+          <div style={{ width: '72px', height: '72px', borderRadius: '18px', background: 'rgba(254,218,106,0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '1.2rem' }}>
+            <img src={powerTokenImg} alt="Power Token" style={{ width: '44px', height: '44px' }} />
+          </div>
+          <h5 style={{ color: '#f1f5f9', fontSize: '1.2rem', fontWeight: '700', marginBottom: '0.5rem' }}>
             Exchange for Power Tokens
           </h5>
-          <p style={{
-            color: '#393f4d',
-            fontSize: '1rem',
-            marginBottom: '1.5rem',
-            lineHeight: '1.5',
-          }}>
-            Exchange 1 Coin Token for 2 Power Tokens
+          <p style={{ color: '#64748b', fontSize: '0.9rem', marginBottom: '1.5rem', lineHeight: '1.6' }}>
+            Spend 1 Coin Token to receive 2 Power Tokens
           </p>
           <button
             onClick={handleExchangePowerTokens}
-            style={{
-              backgroundColor: '#feda6a',
-              color: '#1d1e22',
-              border: 'none',
-              width: '100%',
-              padding: '0.75rem',
-              borderRadius: '10px',
-              fontSize: '1rem',
-              fontWeight: '600',
-              transition: 'background-color 0.3s ease, transform 0.3s ease',
-            }}
-            onMouseOver={(e) => {
-              e.target.style.backgroundColor = '#fee08f';
-              e.target.style.transform = 'scale(1.05)';
-            }}
-            onMouseOut={(e) => {
-              e.target.style.backgroundColor = '#feda6a';
-              e.target.style.transform = 'scale(1)';
-            }}
+            style={btnBase}
+            onMouseOver={(e) => { e.target.style.background = '#fdc53f'; e.target.style.transform = 'translateY(-1px)'; }}
+            onMouseOut={(e) => { e.target.style.background = '#feda6a'; e.target.style.transform = 'translateY(0)'; }}
           >
-            Exchange Now
+            <i className="bi bi-arrow-left-right" style={{ marginRight: '8px' }}></i>Exchange Now
           </button>
         </div>
+
         {/* Coins */}
-        <div style={{
-          backgroundColor: '#ffffff',
-          borderRadius: '20px',
-          padding: '2rem',
-          boxShadow: '0 8px 24px rgba(0, 0, 0, 0.1)',
-          transition: 'transform 0.3s ease, box-shadow 0.3s ease',
-          animation: 'slideIn 0.5s ease-out 0.2s',
-          animationFillMode: 'backwards',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          textAlign: 'center',
-        }}
-        onMouseEnter={(e) => {
-          e.currentTarget.style.transform = 'translateY(-10px)';
-          e.currentTarget.style.boxShadow = '0 12px 32px rgba(254, 218, 106, 0.3)';
-        }}
-        onMouseLeave={(e) => {
-          e.currentTarget.style.transform = 'translateY(0)';
-          e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.1)';
-        }}
+        <div
+          style={cardBase}
+          onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-8px)'; e.currentTarget.style.boxShadow = '0 16px 48px rgba(254,218,106,0.12)'; e.currentTarget.style.borderColor = 'rgba(254,218,106,0.25)'; }}
+          onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'rgba(255,255,255,0.07)'; }}
         >
-          <img
-            src={coinTokenImg}
-            alt="Coin Token"
-            style={{ width: '80px', height: '80px', marginBottom: '1rem' }}
-          />
-          <h5 style={{
-            color: '#1d1e22',
-            fontSize: '1.5rem',
-            fontWeight: '600',
-            marginBottom: '1rem',
-          }}>
+          <div style={{ width: '72px', height: '72px', borderRadius: '18px', background: 'rgba(99,179,237,0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '1.2rem' }}>
+            <img src={coinTokenImg} alt="Coin Token" style={{ width: '44px', height: '44px' }} />
+          </div>
+          <h5 style={{ color: '#f1f5f9', fontSize: '1.2rem', fontWeight: '700', marginBottom: '0.5rem' }}>
             Buy Coins
           </h5>
-          <p style={{
-            color: '#393f4d',
-            fontSize: '1rem',
-            marginBottom: '1.5rem',
-            lineHeight: '1.5',
-          }}>
+          <p style={{ color: '#64748b', fontSize: '0.9rem', marginBottom: '0.5rem', lineHeight: '1.6' }}>
             Get 10 Coins for ₹50
           </p>
+          <div style={{ background: 'rgba(99,179,237,0.1)', color: '#63b3ed', borderRadius: '12px', padding: '4px 14px', fontSize: '0.8rem', fontWeight: '600', marginBottom: '1.5rem' }}>
+            ₹5 per coin
+          </div>
           <button
-            onClick={() => handlePayment(
-              'coinTokens',
-              5000, // Amount in paise (₹50)
-              'Purchase 10 Coins',
-              'Successfully purchased 10 Coins!'
-            )}
-            style={{
-              backgroundColor: '#feda6a',
-              color: '#1d1e22',
-              border: 'none',
-              width: '100%',
-              padding: '0.75rem',
-              borderRadius: '10px',
-              fontSize: '1rem',
-              fontWeight: '600',
-              transition: 'background-color 0.3s ease, transform 0.3s ease',
-            }}
-            onMouseOver={(e) => {
-              e.target.style.backgroundColor = '#fee08f';
-              e.target.style.transform = 'scale(1.05)';
-            }}
-            onMouseOut={(e) => {
-              e.target.style.backgroundColor = '#feda6a';
-              e.target.style.transform = 'scale(1)';
-            }}
+            onClick={() => handlePayment('coinTokens', 5000, 'Purchase 10 Coins', 'Successfully purchased 10 Coins!')}
+            style={btnBase}
+            onMouseOver={(e) => { e.target.style.background = '#fdc53f'; e.target.style.transform = 'translateY(-1px)'; }}
+            onMouseOut={(e) => { e.target.style.background = '#feda6a'; e.target.style.transform = 'translateY(0)'; }}
           >
-            Buy Now
+            <i className="bi bi-cart-fill" style={{ marginRight: '8px' }}></i>Buy Now — ₹50
           </button>
         </div>
-        {/* Premium Plan (Hidden for Premium Users) */}
+
+        {/* Premium Plan */}
         {!user?.premium && (
-          <div style={{
-            backgroundColor: '#ffffff',
-            borderRadius: '20px',
-            padding: '2rem',
-            boxShadow: '0 8px 24px rgba(0, 0, 0, 0.1)',
-            transition: 'transform 0.3s ease, box-shadow 0.3s ease',
-            animation: 'slideIn 0.5s ease-out 0.4s',
-            animationFillMode: 'backwards',
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'center',
-            textAlign: 'center',
-          }}
-          onMouseEnter={(e) => {
-            e.currentTarget.style.transform = 'translateY(-10px)';
-            e.currentTarget.style.boxShadow = '0 12px 32px rgba(254, 218, 106, 0.3)';
-          }}
-          onMouseLeave={(e) => {
-            e.currentTarget.style.transform = 'translateY(0)';
-            e.currentTarget.style.boxShadow = '0 8px 24px rgba(0, 0, 0, 0.1)';
-          }}
+          <div
+            style={{ ...cardBase, border: '1px solid rgba(254,218,106,0.3)', background: 'rgba(254,218,106,0.05)' }}
+            onMouseEnter={(e) => { e.currentTarget.style.transform = 'translateY(-8px)'; e.currentTarget.style.boxShadow = '0 16px 48px rgba(254,218,106,0.18)'; e.currentTarget.style.borderColor = 'rgba(254,218,106,0.5)'; }}
+            onMouseLeave={(e) => { e.currentTarget.style.transform = 'translateY(0)'; e.currentTarget.style.boxShadow = 'none'; e.currentTarget.style.borderColor = 'rgba(254,218,106,0.3)'; }}
           >
-            <img
-              src={premiumImg}
-              alt="Premium Plan"
-              style={{ width: '80px', height: '80px', marginBottom: '1rem' }}
-            />
-            <h5 style={{
-              color: '#1d1e22',
-              fontSize: '1.5rem',
-              fontWeight: '600',
-              marginBottom: '1rem',
-            }}>
-              Buy Premium Plan
+            <div style={{ width: '72px', height: '72px', borderRadius: '18px', background: 'rgba(254,218,106,0.15)', display: 'flex', alignItems: 'center', justifyContent: 'center', marginBottom: '1.2rem' }}>
+              <img src={premiumImg} alt="Premium" style={{ width: '44px', height: '44px' }} />
+            </div>
+            <div style={{ background: 'rgba(254,218,106,0.15)', color: '#feda6a', borderRadius: '20px', padding: '3px 12px', fontSize: '0.75rem', fontWeight: '700', letterSpacing: '0.08em', textTransform: 'uppercase', marginBottom: '0.8rem' }}>
+              Best Value
+            </div>
+            <h5 style={{ color: '#feda6a', fontSize: '1.2rem', fontWeight: '700', marginBottom: '0.5rem' }}>
+              Premium Plan
             </h5>
-            <p style={{
-              color: '#393f4d',
-              fontSize: '1rem',
-              marginBottom: '1.5rem',
-              lineHeight: '1.5',
-            }}>
-              Get Premium + 50 Coins for ₹500
+            <p style={{ color: '#94a3b8', fontSize: '0.9rem', marginBottom: '0.5rem', lineHeight: '1.6' }}>
+              Unlock Premium + 50 Coins
             </p>
+            <ul style={{ color: '#64748b', fontSize: '0.82rem', textAlign: 'left', listStyle: 'none', padding: 0, marginBottom: '1.5rem', width: '100%' }}>
+              <li style={{ marginBottom: '4px' }}><i className="bi bi-check-circle-fill" style={{ color: '#4ade80', marginRight: '8px' }}></i>Selective calls to any user</li>
+              <li style={{ marginBottom: '4px' }}><i className="bi bi-check-circle-fill" style={{ color: '#4ade80', marginRight: '8px' }}></i>View all users</li>
+              <li style={{ marginBottom: '4px' }}><i className="bi bi-check-circle-fill" style={{ color: '#4ade80', marginRight: '8px' }}></i>Email users directly</li>
+              <li><i className="bi bi-check-circle-fill" style={{ color: '#4ade80', marginRight: '8px' }}></i>50 Coins included</li>
+            </ul>
             <button
-              onClick={() => handlePayment(
-                'premium',
-                50000, // Amount in paise (₹500)
-                'Purchase Premium Plan',
-                'Premium plan activated with 50 Coins!'
-              )}
-              style={{
-                backgroundColor: '#feda6a',
-                color: '#1d1e22',
-                border: 'none',
-                width: '100%',
-                padding: '0.75rem',
-                borderRadius: '10px',
-                fontSize: '1rem',
-                fontWeight: '600',
-                transition: 'background-color 0.3s ease, transform 0.3s ease',
-              }}
-              onMouseOver={(e) => {
-                e.target.style.backgroundColor = '#fee08f';
-                e.target.style.transform = 'scale(1.05)';
-              }}
-              onMouseOut={(e) => {
-                e.target.style.backgroundColor = '#feda6a';
-                e.target.style.transform = 'scale(1)';
-              }}
+              onClick={() => handlePayment('premium', 50000, 'Purchase Premium Plan', 'Premium plan activated with 50 Coins!')}
+              style={btnBase}
+              onMouseOver={(e) => { e.target.style.background = '#fdc53f'; e.target.style.transform = 'translateY(-1px)'; }}
+              onMouseOut={(e) => { e.target.style.background = '#feda6a'; e.target.style.transform = 'translateY(0)'; }}
             >
-              Buy Now
+              <i className="bi bi-star-fill" style={{ marginRight: '8px' }}></i>Upgrade — ₹500
             </button>
           </div>
         )}
       </div>
 
-      <style>
-        {`
-          @keyframes slideIn {
-            from { transform: translateY(30px); opacity: 0; }
-            to { transform: translateY(0); opacity: 1; }
-          }
-          @keyframes fadeIn {
-            from { opacity: 0; }
-            to { opacity: 1; }
-          }
-          @media (max-width: 600px) {
-            div[style*="gridTemplateColumns"] {
-              grid-template-columns: 1fr;
-            }
-          }
-        `}
-      </style>
+      <style>{`
+        @keyframes slideIn { from { transform: translateY(24px); opacity: 0; } to { transform: translateY(0); opacity: 1; } }
+      `}</style>
     </div>
   );
 };

--- a/language-exchange-frontend/src/components/UpdateProfile.jsx
+++ b/language-exchange-frontend/src/components/UpdateProfile.jsx
@@ -1,108 +1,22 @@
-
-
-
-// import React, { useState, useEffect } from 'react';
-// import { useNavigate } from 'react-router-dom';
-// import { useGetProfileQuery, useUpdateProfileMutation } from '../redux/services/authApi';
-
-// const UpdateProfile = () => {
-//   const { data, error, isLoading } = useGetProfileQuery();
-//   const [updateProfile, { isLoading: isUpdating }] = useUpdateProfileMutation();
-//   const navigate = useNavigate();
-
-//   const [name, setName] = useState('');
-//   const [knownLanguages, setKnownLanguages] = useState('');
-//   const [learnLanguages, setLearnLanguages] = useState('');
-
-//   // Pre-populate fields with current profile data
-//   useEffect(() => {
-//     if (data?.user) {
-//       setName(data.user.name || '');
-//       setKnownLanguages(data.user.knownLanguages?.join(', ') || '');
-//       setLearnLanguages(data.user.learnLanguages?.join(', ') || '');
-//     }
-//   }, [data]);
-
-//   const handleSubmit = async (e) => {
-//     e.preventDefault();
-//     try {
-//       const profileData = {
-//         name,
-//         knownLanguages: knownLanguages ? knownLanguages.split(',').map(lang => lang.trim()) : [],
-//         learnLanguages: learnLanguages ? learnLanguages.split(',').map(lang => lang.trim()) : [],
-//       };
-//       await updateProfile(profileData).unwrap();
-//       alert('Profile updated successfully');
-//       navigate('/profile'); // Redirect back to profile
-//     } catch (err) {
-//       alert(err.data?.message || 'Failed to update profile');
-//     }
-//   };
-
-//   if (isLoading) return <div>Loading...</div>;
-//   if (error) return <div>Error: {error.data?.message || 'Failed to load profile'}</div>;
-
-//   return (
-//     <div className="container mt-5">
-//       <h2>Update Profile</h2>
-//       <form onSubmit={handleSubmit}>
-//         <div className="mb-3">
-//           <label htmlFor="name" className="form-label">
-//             Name
-//           </label>
-//           <input
-//             type="text"
-//             className="form-control"
-//             id="name"
-//             value={name}
-//             onChange={(e) => setName(e.target.value)}
-//             placeholder="Enter your name"
-//           />
-//         </div>
-//         <div className="mb-3">
-//           <label htmlFor="knownLanguages" className="form-label">
-//             Known Languages (comma-separated)
-//           </label>
-//           <input
-//             type="text"
-//             className="form-control"
-//             id="knownLanguages"
-//             value={knownLanguages}
-//             onChange={(e) => setKnownLanguages(e.target.value)}
-//             placeholder="e.g., English, French"
-//           />
-//         </div>
-//         <div className="mb-3">
-//           <label htmlFor="learnLanguages" className="form-label">
-//             Languages to Learn (comma-separated)
-//           </label>
-//           <input
-//             type="text"
-//             className="form-control"
-//             id="learnLanguages"
-//             value={learnLanguages}
-//             onChange={(e) => setLearnLanguages(e.target.value)}
-//             placeholder="e.g., Spanish, German"
-//           />
-//         </div>
-//         <button type="submit" className="btn btn-primary" disabled={isUpdating}>
-//           {isUpdating ? 'Updating...' : 'Update Profile'}
-//         </button>
-//       </form>
-//     </div>
-//   );
-// };
-
-// export default UpdateProfile;
-
-
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-// --- IMPORT BOTH HOOKS FROM THE SAME API FILE ---
 import { useGetProfileQuery, useUpdateProfileMutation } from '../redux/services/userApi';
+import { toast } from 'react-toastify';
+
+const inputStyle = (focused) => ({
+  width: '100%',
+  padding: '10px 14px',
+  borderRadius: '10px',
+  border: focused ? '1px solid rgba(254,218,106,0.55)' : '1px solid rgba(255,255,255,0.12)',
+  background: 'rgba(255,255,255,0.06)',
+  color: '#f1f5f9',
+  fontSize: '0.9rem',
+  outline: 'none',
+  transition: 'border-color 0.2s, box-shadow 0.2s',
+  boxShadow: focused ? '0 0 0 3px rgba(254,218,106,0.12)' : 'none',
+});
 
 const UpdateProfile = () => {
-  // This now calls the single, consolidated getProfile query
   const { data, error, isLoading } = useGetProfileQuery();
   const [updateProfile, { isLoading: isUpdating }] = useUpdateProfileMutation();
   const navigate = useNavigate();
@@ -110,6 +24,7 @@ const UpdateProfile = () => {
   const [name, setName] = useState('');
   const [knownLanguages, setKnownLanguages] = useState('');
   const [learnLanguages, setLearnLanguages] = useState('');
+  const [focused, setFocused] = useState('');
 
   useEffect(() => {
     if (data?.user) {
@@ -123,68 +38,108 @@ const UpdateProfile = () => {
     e.preventDefault();
     try {
       const profileData = {
-        name,
-        knownLanguages: knownLanguages ? knownLanguages.split(',').map(lang => lang.trim()) : [],
-        learnLanguages: learnLanguages ? learnLanguages.split(',').map(lang => lang.trim()) : [],
+        name: name.trim(),
+        knownLanguages: knownLanguages
+          ? knownLanguages.split(',').map(l => l.trim().toLowerCase()).filter(Boolean)
+          : [],
+        learnLanguages: learnLanguages
+          ? learnLanguages.split(',').map(l => l.trim().toLowerCase()).filter(Boolean)
+          : [],
       };
       await updateProfile(profileData).unwrap();
-      alert('Profile updated successfully');
+      toast.success('Profile updated successfully');
       navigate('/profile');
     } catch (err) {
-      alert(err.data?.message || 'Failed to update profile');
+      toast.error(err.data?.message || 'Failed to update profile');
     }
   };
 
-  if (isLoading) return <div>Loading...</div>;
-  if (error) return <div>Error: {error.data?.message || 'Failed to load profile'}</div>;
+  if (isLoading) return <div style={{ color: '#94a3b8', textAlign: 'center', marginTop: '80px' }}>Loading…</div>;
+  if (error) return <div style={{ color: '#fc8181', textAlign: 'center', marginTop: '80px' }}>Error loading profile</div>;
 
   return (
-    <div className="container mt-5">
-      <h2>Update Profile</h2>
-      <form onSubmit={handleSubmit}>
-        <div className="mb-3">
-          <label htmlFor="name" className="form-label">
-            Name
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="name"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder="Enter your name"
-          />
+    <div style={{ background: '#0f1117', minHeight: '100vh', padding: '3rem 1rem', fontFamily: "'Inter', sans-serif" }}>
+      <div style={{ maxWidth: '520px', margin: '0 auto' }}>
+
+        <div style={{ background: 'rgba(22,25,35,0.92)', border: '1px solid rgba(255,255,255,0.07)', borderRadius: '20px', padding: '2rem', backdropFilter: 'blur(12px)' }}>
+
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px', marginBottom: '1.8rem' }}>
+            <div style={{ width: '44px', height: '44px', borderRadius: '12px', background: 'rgba(254,218,106,0.12)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+              <i className="bi bi-pencil-fill" style={{ fontSize: '1.2rem', color: '#feda6a' }}></i>
+            </div>
+            <div>
+              <h2 style={{ color: '#f1f5f9', fontWeight: '800', margin: 0, fontSize: '1.3rem' }}>Update Profile</h2>
+              <p style={{ color: '#64748b', margin: 0, fontSize: '0.82rem' }}>Languages are saved in lowercase automatically</p>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit}>
+            <div style={{ marginBottom: '1.2rem' }}>
+              <label style={{ color: '#94a3b8', fontSize: '0.82rem', fontWeight: '600', display: 'block', marginBottom: '6px' }}>Display Name</label>
+              <input
+                type="text"
+                placeholder="Your name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                style={inputStyle(focused === 'name')}
+                onFocus={() => setFocused('name')}
+                onBlur={() => setFocused('')}
+              />
+            </div>
+
+            <div style={{ marginBottom: '1.2rem' }}>
+              <label style={{ color: '#94a3b8', fontSize: '0.82rem', fontWeight: '600', display: 'block', marginBottom: '6px' }}>
+                <i className="bi bi-chat-quote-fill" style={{ color: '#feda6a', marginRight: '6px' }}></i>
+                Known Languages
+                <span style={{ color: '#475569', fontWeight: '400', marginLeft: '6px' }}>(comma-separated)</span>
+              </label>
+              <input
+                type="text"
+                placeholder="e.g., English, French"
+                value={knownLanguages}
+                onChange={(e) => setKnownLanguages(e.target.value)}
+                style={inputStyle(focused === 'known')}
+                onFocus={() => setFocused('known')}
+                onBlur={() => setFocused('')}
+              />
+            </div>
+
+            <div style={{ marginBottom: '2rem' }}>
+              <label style={{ color: '#94a3b8', fontSize: '0.82rem', fontWeight: '600', display: 'block', marginBottom: '6px' }}>
+                <i className="bi bi-translate" style={{ color: '#63b3ed', marginRight: '6px' }}></i>
+                Learning Languages
+                <span style={{ color: '#475569', fontWeight: '400', marginLeft: '6px' }}>(comma-separated)</span>
+              </label>
+              <input
+                type="text"
+                placeholder="e.g., Spanish, German"
+                value={learnLanguages}
+                onChange={(e) => setLearnLanguages(e.target.value)}
+                style={inputStyle(focused === 'learn')}
+                onFocus={() => setFocused('learn')}
+                onBlur={() => setFocused('')}
+              />
+            </div>
+
+            <div style={{ display: 'flex', gap: '0.8rem' }}>
+              <button
+                type="button"
+                onClick={() => navigate('/profile')}
+                style={{ flex: 1, padding: '10px', borderRadius: '12px', border: '1px solid rgba(255,255,255,0.1)', background: 'transparent', color: '#94a3b8', fontWeight: '600', fontSize: '0.9rem', cursor: 'pointer' }}
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={isUpdating}
+                style={{ flex: 2, padding: '10px', borderRadius: '12px', border: 'none', background: isUpdating ? 'rgba(254,218,106,0.4)' : '#feda6a', color: '#1d1e22', fontWeight: '700', fontSize: '0.9rem', cursor: isUpdating ? 'not-allowed' : 'pointer', transition: 'background 0.2s' }}
+              >
+                {isUpdating ? 'Saving…' : 'Save Changes'}
+              </button>
+            </div>
+          </form>
         </div>
-        <div className="mb-3">
-          <label htmlFor="knownLanguages" className="form-label">
-            Known Languages (comma-separated)
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="knownLanguages"
-            value={knownLanguages}
-            onChange={(e) => setKnownLanguages(e.target.value)}
-            placeholder="e.g., English, French"
-          />
-        </div>
-        <div className="mb-3">
-          <label htmlFor="learnLanguages" className="form-label">
-            Languages to Learn (comma-separated)
-          </label>
-          <input
-            type="text"
-            className="form-control"
-            id="learnLanguages"
-            value={learnLanguages}
-            onChange={(e) => setLearnLanguages(e.target.value)}
-            placeholder="e.g., Spanish, German"
-          />
-        </div>
-        <button type="submit" className="btn btn-primary" disabled={isUpdating}>
-          {isUpdating ? 'Updating...' : 'Update Profile'}
-        </button>
-      </form>
+      </div>
     </div>
   );
 };

--- a/language-exchange-frontend/src/hooks/useCallLogic.js
+++ b/language-exchange-frontend/src/hooks/useCallLogic.js
@@ -717,15 +717,16 @@ const useCallLogic = () => {
           'Content-Type': 'application/json',
           'Authorization': `Bearer ${localStorage.getItem('token')}`,
         },
-        body: JSON.stringify({ language }),
+        body: JSON.stringify({ language: language.trim().toLowerCase() }),
       });
       const data = await response.json();
       if (response.status === 200) {
+        const normalizedLanguage = language.trim().toLowerCase();
         dispatch(setCallStatus({
           callId: data.callId,
           status: 'pending',
           receivers: data.potentialReceivers,
-          language,
+          language: normalizedLanguage,
           callerId: user?._id,
           caller: user?.name,
           startTime: new Date().toISOString(),

--- a/language-exchange-frontend/src/index.css
+++ b/language-exchange-frontend/src/index.css
@@ -1,2 +1,145 @@
 @import 'bootstrap/dist/css/bootstrap.min.css';
 @import 'bootstrap-icons/font/bootstrap-icons.css';
+
+/* ── Global dark base ───────────────────────────────────────────────── */
+body {
+  background-color: #0f1117;
+  color: #e2e8f0;
+  font-family: 'Inter', 'Arial', sans-serif;
+}
+
+/* ── Modal backdrop — semi-transparent so hero shows through ───────── */
+.modal-backdrop {
+  background-color: rgba(5, 6, 10, 0.7) !important;
+  backdrop-filter: blur(6px) !important;
+  -webkit-backdrop-filter: blur(6px) !important;
+}
+
+/* ── Glassmorphism modal card ──────────────────────────────────────── */
+.modal-content {
+  background: rgba(18, 20, 30, 0.92) !important;
+  border: 1px solid rgba(254, 218, 106, 0.18) !important;
+  border-radius: 20px !important;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(255,255,255,0.04) !important;
+  backdrop-filter: blur(16px) !important;
+  -webkit-backdrop-filter: blur(16px) !important;
+  color: #e2e8f0 !important;
+}
+
+.modal-header {
+  border-bottom: 1px solid rgba(255,255,255,0.07) !important;
+  padding: 1.25rem 1.5rem !important;
+}
+
+.modal-title {
+  color: #feda6a !important;
+  font-weight: 700 !important;
+  font-size: 1.15rem !important;
+}
+
+.btn-close {
+  filter: invert(1) brightness(0.7) !important;
+}
+
+.modal-body {
+  padding: 1.5rem !important;
+}
+
+/* ── Modal form inputs ─────────────────────────────────────────────── */
+.modal-content .form-label {
+  color: #94a3b8;
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin-bottom: 6px;
+}
+
+.modal-content .form-control {
+  background: rgba(255,255,255,0.06) !important;
+  border: 1px solid rgba(255,255,255,0.12) !important;
+  color: #f1f5f9 !important;
+  border-radius: 10px !important;
+  padding: 10px 14px !important;
+  font-size: 0.9rem !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+}
+.modal-content .form-control::placeholder {
+  color: rgba(255,255,255,0.3) !important;
+}
+.modal-content .form-control:focus {
+  border-color: rgba(254, 218, 106, 0.55) !important;
+  box-shadow: 0 0 0 3px rgba(254, 218, 106, 0.12) !important;
+  background: rgba(255,255,255,0.09) !important;
+  outline: none !important;
+}
+
+/* ── Modal primary submit button ──────────────────────────────────── */
+.modal-content .btn-primary {
+  background: #feda6a !important;
+  border: none !important;
+  color: #1d1e22 !important;
+  font-weight: 700 !important;
+  border-radius: 10px !important;
+  padding: 10px !important;
+  transition: background 0.2s, transform 0.15s !important;
+}
+.modal-content .btn-primary:hover:not(:disabled) {
+  background: #fdc53f !important;
+  transform: translateY(-1px) !important;
+}
+.modal-content .btn-primary:disabled {
+  opacity: 0.45 !important;
+  cursor: not-allowed !important;
+}
+
+/* ── Modal Google / outline button ────────────────────────────────── */
+.modal-content .btn-outline-primary {
+  background: transparent !important;
+  border: 1px solid rgba(254, 218, 106, 0.35) !important;
+  color: #feda6a !important;
+  font-weight: 600 !important;
+  border-radius: 10px !important;
+  padding: 10px !important;
+  transition: background 0.2s, border-color 0.2s !important;
+}
+.modal-content .btn-outline-primary:hover {
+  background: rgba(254, 218, 106, 0.1) !important;
+  border-color: rgba(254, 218, 106, 0.6) !important;
+}
+
+/* ── Modal link buttons ────────────────────────────────────────────── */
+.modal-content .btn-link {
+  color: #feda6a !important;
+  font-weight: 600 !important;
+  text-decoration: none !important;
+  border-bottom: 1px solid rgba(254,218,106,0.4) !important;
+  padding: 0 !important;
+  border-radius: 0 !important;
+  transition: border-color 0.2s !important;
+}
+.modal-content .btn-link:hover {
+  border-color: #feda6a !important;
+}
+
+/* ── OR divider ────────────────────────────────────────────────────── */
+.modal-content hr {
+  border-color: rgba(255,255,255,0.1) !important;
+}
+.modal-content .text-muted {
+  color: #475569 !important;
+}
+
+/* ── Forgot password link ──────────────────────────────────────────── */
+.modal-content .text-end .btn-link {
+  font-size: 0.82rem;
+  color: #94a3b8 !important;
+  border-bottom: none !important;
+}
+.modal-content .text-end .btn-link:hover {
+  color: #feda6a !important;
+}
+
+/* ── "Don't have an account?" text ────────────────────────────────── */
+.modal-content p.text-center {
+  color: #64748b;
+  font-size: 0.88rem;
+}

--- a/language-exchange-frontend/src/styles/Home.css
+++ b/language-exchange-frontend/src/styles/Home.css
@@ -1,315 +1,438 @@
 body {
-    background-color: #FFFFFF;
-    color: #393f4d;
-    font-family: 'Arial', sans-serif;
-    margin: 0;
-    padding: 0;
-  }
-  
-  /* Hero Section */
-  .hero-section {
-    background: linear-gradient(rgba(29, 30, 34, 0.7), rgba(29, 30, 34, 0.7)),
-                url('https://images.unsplash.com/photo-1529156069898-49953e39b3ac?ixlib=rb-4.0.3&auto=format&fit=crop&w=1350&q=80');
-    background-size: cover;
-    background-position: center;
-    padding: 120px 0;
-    text-align: center;
-    color: #feda6a;
-    position: relative;
-    overflow: hidden;
-    animation: fadeIn 1s ease-in;
-  }
-  
-  @keyframes fadeIn {
-    from { opacity: 0; }
-    to { opacity: 1; }
-  }
-  
-  .hero-title {
-    font-size: 4rem;
-    font-weight: 700;
-    margin-bottom: 1rem;
-    animation: slideUp 1s ease-out;
-  }
-  
-  .hero-subtitle {
-    font-size: 1.8rem;
-    animation: slideUp 1.2s ease-out;
-  }
-  
-  @keyframes slideUp {
-    from { transform: translateY(30px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
-  }
-  
-  .globe {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 250px;
-    height: 250px;
-    background: url('https://www.freeiconspng.com/uploads/globe-icon-png-0.png') no-repeat center;
-    background-size: contain;
-    opacity: 0.15;
-    animation: spin 15s linear infinite;
-  }
-  
-  @keyframes spin {
-    from { transform: translate(-50%, -50%) rotate(0deg); }
-    to { transform: translate(-50%, -50%) rotate(360deg); }
-  }
-  
-  .particles {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    pointer-events: none;
-  }
-  
-  .particle {
-    position: absolute;
-    width: 8px;
-    height: 8px;
-    background: rgba(254, 218, 106, 0.5);
-    border-radius: 50%;
-    animation: float 6s infinite ease-in-out;
-  }
-  
-  .particle:nth-child(1) { left: 10%; top: 20%; animation-delay: 0s; }
-  .particle:nth-child(2) { left: 30%; top: 60%; animation-delay: 1s; }
-  .particle:nth-child(3) { left: 70%; top: 30%; animation-delay: 2s; }
-  .particle:nth-child(4) { left: 50%; top: 80%; animation-delay: 3s; }
-  
-  @keyframes float {
-    0%, 100% { transform: translateY(0); opacity: 0.5; }
-    50% { transform: translateY(-20px); opacity: 0.8; }
-  }
-  
-  /* Call Initiator */
-  .call-initiator {
-    background-color: #d4d4dc;
-    border-radius: 15px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    padding: 1.5rem;
-    max-width: 600px;
-    margin: -60px auto 2rem;
-    position: relative;
-    z-index: 10;
-    animation: bounceIn 0.8s ease-out;
-  }
-  
-  @keyframes bounceIn {
-    0% { transform: scale(0.8); opacity: 0; }
-    60% { transform: scale(1.05); opacity: 1; }
-    100% { transform: scale(1); }
-  }
-  
-  .call-initiator h5 {
-    color: #1d1e22;
-    font-weight: 600;
-    margin-bottom: 1rem;
-  }
-  
-  /* Feature Section */
-  .feature-section {
-    padding: 60px 0;
-  }
-  
-  .feature-card {
-    background-color: #d4d4dc;
-    border-radius: 10px;
-    padding: 20px;
-    text-align: center;
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-    animation: slideIn 0.5s ease-out forwards;
-  }
-  
-  .feature-card:nth-child(1) { animation-delay: 0.1s; }
-  .feature-card:nth-child(2) { animation-delay: 0.3s; }
-  .feature-card:nth-child(3) { animation-delay: 0.5s; }
-  
-  .feature-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
-  }
-  
-  @keyframes slideIn {
-    from { transform: translateY(20px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
-  }
-  
-  .feature-icon {
-    font-size: 2.5rem;
-    color: #1d1e22;
-    margin-bottom: 1rem;
-  }
-  
-  /* Call Card */
-  .call-card {
-    background-color: #d4d4dc;
-    border-radius: 15px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
-    padding: 2rem;
-    max-width: 500px;
-    margin: 2rem auto;
-    animation: slideInCard 0.5s ease-out;
-  }
-  
-  @keyframes slideInCard {
-    from { transform: translateX(-50px); opacity: 0; }
-    to { transform: translateX(0); opacity: 1; }
-  }
-  
-  .call-card h5 {
-    color: #1d1e22;
-    font-weight: 600;
-  }
-  
-  .call-card p {
-    color: #393f4d;
-  }
-  
-  /* Buttons */
-  .btn-primary-custom {
-    background-color: #1d1e22;
-    border: none;
-    color: #feda6a;
-    padding: 12px 24px;
-    border-radius: 8px;
-    transition: background-color 0.3s ease, transform 0.2s ease;
-    animation: pulse 2s infinite;
-  }
-  
-  .btn-primary-custom:hover {
-    background-color: #151618;
-    transform: scale(1.05);
-  }
-  
-  .btn-success-custom {
-    background-color: #feda6a;
-    border: none;
-    color: #1d1e22;
-    padding: 10px 20px;
-    border-radius: 8px;
-    transition: background-color 0.3s ease, transform 0.2s ease;
-    animation: pulse 2s infinite;
-  }
-  
-  .btn-success-custom:hover {
-    background-color: #fdc53f;
-    transform: scale(1.05);
-  }
-  
-  .btn-danger-custom {
-    background-color: #393f4d;
-    border: none;
-    color: #feda6a;
-    padding: 10px 20px;
-    border-radius: 8px;
-    transition: background-color 0.3s ease, transform 0.2s ease;
-    animation: pulse 2s infinite;
-  }
-  
-  .btn-danger-custom:hover {
-    background-color: #2c303b;
-    transform: scale(1.05);
-  }
-  
-  .btn-warning-custom {
-    background-color: #feda6a;
-    border: none;
-    color: #1d1e22;
-    padding: 10px 20px;
-    border-radius: 8px;
-    transition: background-color 0.3s ease, transform 0.2s ease;
-    animation: pulse 2s infinite;
-  }
-  
-  .btn-warning-custom:hover {
-    background-color: #fdc53f;
-    transform: scale(1.05);
-  }
-  
-  .btn-secondary-custom {
-    background-color: #393f4d;
-    border: none;
-    color: #feda6a;
-    padding: 10px 20px;
-    border-radius: 8px;
-    transition: background-color 0.3s ease, transform 0.2s ease;
-    animation: pulse 2s infinite;
-  }
-  
-  .btn-secondary-custom:hover {
-    background-color: #2c303b;
-    transform: scale(1.05);
-  }
-  
-  @keyframes pulse {
-    0%, 100% { transform: scale(1); }
-    50% { transform: scale(1.03); }
-  }
-  
-  /* Alert */
-  .alert-info-custom {
-    background-color: #d4d4dc;
-    border-color: #feda6a;
-    color: #393f4d;
-    border-radius: 10px;
-    padding: 1rem;
-    animation: fadeIn 0.5s ease-in;
-  }
-  
-  .alert-info-custom a {
-    color: #1d1e22;
-    font-weight: bold;
-    text-decoration: none;
-  }
-  
-  .alert-info-custom a:hover {
-    color: #151618;
-  }
-  
-  /* Input */
-  input.form-control {
-    border-color: #d4d4dc;
-    color: #393f4d;
-    border-radius: 8px;
-    transition: border-color 0.3s ease, box-shadow 0.3s ease;
-  }
-  
-  input.form-control:focus {
-    border-color: #1d1e22;
-    box-shadow: 0 0 5px rgba(29, 30, 34, 0.5);
-  }
-  
-  /* Progress Bar */
-  .progress-bar-container {
-    margin: 1rem 0;
-  }
-  
-  .progress-bar {
-    height: 10px;
-    background-color: #feda6a;
-    border-radius: 5px;
-    transition: width 1s ease-in-out;
-  }
-  
-  /* Footer */
-  .footer {
-    background-color: #1d1e22;
-    color: #feda6a;
-    padding: 20px 0;
-    text-align: center;
-    position: relative;
-    animation: fadeInUp 1s ease-out;
-  }
-  
-  @keyframes fadeInUp {
-    from { transform: translateY(20px); opacity: 0; }
-    to { transform: translateY(0); opacity: 1; }
-  }
+  background-color: #0f1117;
+  color: #e2e8f0;
+  font-family: 'Inter', 'Arial', sans-serif;
+  margin: 0;
+  padding: 0;
+}
+
+/* ─── Hero ────────────────────────────────────────────────────────── */
+.hero-section {
+  background: linear-gradient(rgba(10, 11, 15, 0.72), rgba(10, 11, 15, 0.82)),
+              url('https://images.unsplash.com/photo-1529156069898-49953e39b3ac?ixlib=rb-4.0.3&auto=format&fit=crop&w=1350&q=80');
+  background-size: cover;
+  background-position: center;
+  padding: 140px 20px 160px;
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+  animation: fadeIn 1s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.hero-title {
+  font-size: clamp(2.2rem, 5vw, 4rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #feda6a 0%, #ffb347 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+  animation: slideUp 0.9s ease-out;
+}
+
+.hero-subtitle {
+  font-size: clamp(1rem, 2.5vw, 1.4rem);
+  color: #cbd5e1;
+  font-weight: 400;
+  animation: slideUp 1.1s ease-out;
+}
+
+@keyframes slideUp {
+  from { transform: translateY(30px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.globe {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  width: 280px; height: 280px;
+  background: url('https://www.freeiconspng.com/uploads/globe-icon-png-0.png') no-repeat center;
+  background-size: contain;
+  opacity: 0.08;
+  animation: spin 20s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: translate(-50%, -50%) rotate(0deg);   }
+  to   { transform: translate(-50%, -50%) rotate(360deg); }
+}
+
+.particles { position: absolute; top: 0; left: 0; width: 100%; height: 100%; pointer-events: none; }
+
+.particle {
+  position: absolute;
+  width: 6px; height: 6px;
+  background: rgba(254, 218, 106, 0.6);
+  border-radius: 50%;
+  animation: float 7s infinite ease-in-out;
+}
+.particle:nth-child(1) { left: 10%; top: 20%; animation-delay: 0s;   }
+.particle:nth-child(2) { left: 30%; top: 65%; animation-delay: 1.5s; }
+.particle:nth-child(3) { left: 72%; top: 28%; animation-delay: 2.8s; }
+.particle:nth-child(4) { left: 55%; top: 78%; animation-delay: 4s;   }
+
+@keyframes float {
+  0%, 100% { transform: translateY(0);     opacity: 0.5; }
+  50%       { transform: translateY(-22px); opacity: 0.9; }
+}
+
+/* ─── Call Initiator card ─────────────────────────────────────────── */
+.call-initiator {
+  background: rgba(22, 25, 35, 0.92);
+  border: 1px solid rgba(254, 218, 106, 0.18);
+  border-radius: 20px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5), 0 0 0 1px rgba(255,255,255,0.04);
+  padding: 2rem;
+  max-width: 560px;
+  margin: -70px auto 3rem;
+  position: relative;
+  z-index: 10;
+  animation: bounceIn 0.7s ease-out;
+  backdrop-filter: blur(12px);
+}
+
+@keyframes bounceIn {
+  0%   { transform: scale(0.88); opacity: 0; }
+  65%  { transform: scale(1.03); opacity: 1; }
+  100% { transform: scale(1);               }
+}
+
+.call-initiator h5 {
+  color: #feda6a;
+  font-weight: 700;
+  font-size: 1.1rem;
+  margin-bottom: 1rem;
+}
+
+/* ─── Call card (status) ──────────────────────────────────────────── */
+.call-card {
+  background: transparent;
+  padding: 0;
+  width: 100%;
+}
+
+.call-card-title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(254, 218, 106, 0.7);
+  margin-bottom: 1.2rem;
+}
+
+/* Incoming call ring animation */
+.incoming-ring {
+  width: 72px; height: 72px;
+  border-radius: 50%;
+  background: rgba(254, 218, 106, 0.15);
+  display: flex; align-items: center; justify-content: center;
+  margin: 0 auto 1rem;
+  position: relative;
+}
+.incoming-ring::before, .incoming-ring::after {
+  content: '';
+  position: absolute;
+  border: 2px solid rgba(254, 218, 106, 0.4);
+  border-radius: 50%;
+  animation: ripple 1.8s ease-out infinite;
+}
+.incoming-ring::after { animation-delay: 0.9s; }
+@keyframes ripple {
+  0%   { width: 72px;  height: 72px;  opacity: 1; }
+  100% { width: 120px; height: 120px; opacity: 0; }
+}
+
+.incoming-ring i {
+  font-size: 1.8rem;
+  color: #feda6a;
+}
+
+.call-partner-name {
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  margin-bottom: 0.3rem;
+  text-align: center;
+}
+
+.call-language-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(254, 218, 106, 0.12);
+  color: #feda6a;
+  font-size: 0.82rem;
+  font-weight: 600;
+  padding: 3px 12px;
+  border-radius: 20px;
+  margin-bottom: 1.4rem;
+}
+
+/* Duration */
+.call-duration-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #f1f5f9;
+  justify-content: center;
+  margin-bottom: 0.5rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.call-progress-track {
+  height: 4px;
+  background: rgba(255,255,255,0.1);
+  border-radius: 2px;
+  overflow: hidden;
+  margin-bottom: 1.4rem;
+}
+.call-progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 1s linear, background-color 0.3s ease;
+}
+
+/* Call control buttons */
+.call-controls {
+  display: flex;
+  justify-content: center;
+  gap: 1.2rem;
+  margin-bottom: 1rem;
+}
+
+.ctrl-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 5px;
+  border: none;
+  border-radius: 50px;
+  padding: 14px 20px;
+  cursor: pointer;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.15s;
+  min-width: 72px;
+}
+.ctrl-btn i { font-size: 1.3rem; }
+.ctrl-btn:disabled { opacity: 0.38; cursor: not-allowed; }
+.ctrl-btn:not(:disabled):hover { transform: translateY(-2px); box-shadow: 0 6px 20px rgba(0,0,0,0.4); }
+.ctrl-btn:not(:disabled):active { transform: translateY(0); }
+
+.ctrl-btn.mute-btn   { background: rgba(255,255,255,0.1); color: #f1f5f9; }
+.ctrl-btn.muted      { background: rgba(254, 218, 106, 0.2); color: #feda6a; }
+.ctrl-btn.end-btn    { background: #e53e3e; color: #fff; }
+.ctrl-btn.extend-btn { background: rgba(254, 218, 106, 0.15); color: #feda6a; }
+
+/* Wide action buttons */
+.call-btn {
+  display: flex; align-items: center; justify-content: center; gap: 8px;
+  width: 100%; padding: 11px 20px;
+  border: none; border-radius: 12px;
+  font-size: 0.9rem; font-weight: 600; cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, opacity 0.2s;
+}
+.call-btn:hover { transform: translateY(-1px); box-shadow: 0 4px 16px rgba(0,0,0,0.35); }
+.call-btn:active { transform: translateY(0); }
+.call-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+.call-btn-accept  { background: #38a169; color: #fff; }
+.call-btn-reject  { background: #e53e3e; color: #fff; }
+.call-btn-cancel  { background: rgba(229, 62, 62, 0.15); color: #fc8181; border: 1px solid rgba(229,62,62,0.3); }
+.call-btn-primary { background: #feda6a; color: #1d1e22; }
+.call-btn-primary:disabled { background: rgba(254,218,106,0.3); }
+
+.call-extended-badge {
+  display: inline-flex; align-items: center; gap: 6px;
+  background: rgba(254, 218, 106, 0.12);
+  color: #feda6a; font-size: 0.8rem; font-weight: 600;
+  padding: 4px 12px; border-radius: 20px;
+  margin-bottom: 0.8rem;
+}
+
+.extend-request-box {
+  background: rgba(254, 218, 106, 0.08);
+  border: 1px solid rgba(254, 218, 106, 0.2);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-top: 1rem;
+}
+
+/* ─── Language input ──────────────────────────────────────────────── */
+.lang-input-row {
+  display: flex;
+  gap: 0.7rem;
+  align-items: center;
+}
+
+.lang-input {
+  flex: 1;
+  background: rgba(255,255,255,0.07) !important;
+  border: 1px solid rgba(255,255,255,0.15) !important;
+  color: #f1f5f9 !important;
+  border-radius: 10px !important;
+  padding: 10px 14px !important;
+  font-size: 0.9rem !important;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease !important;
+}
+.lang-input::placeholder { color: rgba(255,255,255,0.35) !important; }
+.lang-input:focus {
+  border-color: rgba(254, 218, 106, 0.5) !important;
+  box-shadow: 0 0 0 3px rgba(254, 218, 106, 0.12) !important;
+  background: rgba(255,255,255,0.1) !important;
+  outline: none !important;
+}
+
+/* ─── Not authenticated alert ─────────────────────────────────────── */
+.auth-alert {
+  text-align: center;
+  color: #94a3b8;
+  font-size: 0.95rem;
+  padding: 0.5rem 0;
+}
+.auth-alert a {
+  color: #feda6a;
+  font-weight: 700;
+  text-decoration: none;
+  border-bottom: 1px solid rgba(254,218,106,0.4);
+  transition: border-color 0.2s;
+}
+.auth-alert a:hover { border-color: #feda6a; }
+
+/* ─── Feature section ─────────────────────────────────────────────── */
+.feature-section {
+  padding: 80px 1rem;
+  background: #0f1117;
+}
+
+.feature-section-title {
+  text-align: center;
+  color: #f1f5f9;
+  font-size: 1.9rem;
+  font-weight: 800;
+  margin-bottom: 0.5rem;
+}
+.feature-section-sub {
+  text-align: center;
+  color: #64748b;
+  margin-bottom: 3rem;
+  font-size: 1rem;
+}
+
+.feature-card {
+  background: rgba(22, 25, 35, 0.8);
+  border: 1px solid rgba(255,255,255,0.06);
+  border-radius: 16px;
+  padding: 2rem 1.5rem;
+  text-align: center;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, border-color 0.3s;
+  animation: slideIn 0.5s ease-out forwards;
+  height: 100%;
+}
+.feature-card:nth-child(1) { animation-delay: 0.1s; }
+.feature-card:nth-child(2) { animation-delay: 0.25s; }
+.feature-card:nth-child(3) { animation-delay: 0.4s; }
+
+.feature-card:hover {
+  transform: translateY(-6px);
+  box-shadow: 0 16px 48px rgba(254, 218, 106, 0.12);
+  border-color: rgba(254, 218, 106, 0.25);
+}
+
+@keyframes slideIn {
+  from { transform: translateY(24px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+.feature-icon-wrap {
+  width: 60px; height: 60px;
+  border-radius: 16px;
+  background: rgba(254, 218, 106, 0.12);
+  display: flex; align-items: center; justify-content: center;
+  margin: 0 auto 1.2rem;
+}
+
+.feature-icon {
+  font-size: 1.7rem;
+  color: #feda6a;
+}
+
+.feature-card h5 {
+  color: #f1f5f9;
+  font-weight: 700;
+  font-size: 1.05rem;
+  margin-bottom: 0.5rem;
+}
+
+.feature-card p {
+  color: #64748b;
+  font-size: 0.88rem;
+  line-height: 1.6;
+  margin: 0;
+}
+
+/* ─── Stats strip ─────────────────────────────────────────────────── */
+.stats-strip {
+  background: rgba(254, 218, 106, 0.06);
+  border-top: 1px solid rgba(254, 218, 106, 0.1);
+  border-bottom: 1px solid rgba(254, 218, 106, 0.1);
+  padding: 2.5rem 1rem;
+}
+.stat-item { text-align: center; }
+.stat-number {
+  font-size: 2rem; font-weight: 800;
+  color: #feda6a;
+  line-height: 1;
+}
+.stat-label {
+  font-size: 0.8rem; color: #64748b;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  margin-top: 4px;
+}
+
+/* ─── Footer ──────────────────────────────────────────────────────── */
+.footer {
+  background: #080a0f;
+  border-top: 1px solid rgba(255,255,255,0.06);
+  color: #475569;
+  padding: 28px 0;
+  text-align: center;
+  font-size: 0.85rem;
+  animation: fadeInUp 0.8s ease-out;
+}
+.footer span { color: #feda6a; }
+
+@keyframes fadeInUp {
+  from { transform: translateY(16px); opacity: 0; }
+  to   { transform: translateY(0);    opacity: 1; }
+}
+
+/* ─── Divider ─────────────────────────────────────────────────────── */
+.auth-divider {
+  display: flex; align-items: center; gap: 1rem;
+  color: #475569; font-size: 0.8rem; margin: 0.2rem 0;
+}
+.auth-divider::before, .auth-divider::after {
+  content: ''; flex: 1;
+  height: 1px; background: rgba(255,255,255,0.08);
+}
+
+/* ─── Legacy compat (keeps old btn classes working) ───────────────── */
+.btn-primary-custom {
+  background: #feda6a; border: none; color: #1d1e22;
+  padding: 10px 22px; border-radius: 10px; font-weight: 700;
+  transition: background 0.2s, transform 0.15s;
+  white-space: nowrap;
+}
+.btn-primary-custom:hover:not(:disabled) { background: #fdc53f; transform: translateY(-1px); }
+.btn-primary-custom:disabled { opacity: 0.4; cursor: not-allowed; }


### PR DESCRIPTION
## Summary

- **Dark theme** applied across all pages (Home, Premium, Profile, UpdateProfile, ResetPassword, Store) using glassmorphism cards (`rgba` backgrounds + `backdrop-filter: blur`)
- **Login/Register modals** now render the home page hero visible through a blurred semi-transparent backdrop
- **Call UI redesign** — incoming call ripple animation, Bootstrap Icon control buttons (mute/unmute, end, extend), language tag chips, duration progress bar
- **Language normalization** — all language inputs are `trim().toLowerCase()` before being sent to the API or saved to profile, so "Spanish", " SPANISH ", "spanish" all match correctly
- **Profile page** shows the user's actual name in the header instead of "Your Profile"

## Test plan

- [ ] Home page hero renders with dark background and globe animation
- [ ] Login/Register modal opens with home page visible through blurred backdrop
- [ ] Initiate call with mixed-case language (e.g. "Spanish") — confirm it matches lowercase receiver
- [ ] Active call shows mute/end/extend icon buttons and duration timer
- [ ] Profile page shows name, language chips, and Edit button
- [ ] UpdateProfile saves languages as lowercase
- [ ] ResetPassword page renders dark card

closes #46 